### PR TITLE
Update Germany.cup

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -442,7 +442,7 @@
 "Illeshe Mil Heli",,DE,4928.433N,01023.283E,329.0m,2,060,1500.0m,122.100,"Flugplatz"
 "Imsweiler Donne",,DE,4936.367N,00747.617E,289.0m,3,060,280.0m,130.780,"Landefeld"
 "Ingelfingen Bueh",,DE,4919.300N,00939.817E,421.0m,5,070,480.0m,120.835,"Flugplatz"
-"Ingolstadt Manch",,DE,4842.933N,01132.033E,366.0m,5,070,2940.0m,122.100,"Flugplatz"
+"Ingolstadt Manch",,DE,4842.933N,01132.033E,366.0m,5,070,2940.0m,125.250,"Flugplatz"
 "Ippesheim Ul",,DE,4936.583N,01013.533E,297.0m,3,100,350.0m,120.975,"Landefeld"
 "Irsingen",,DE,4902.300N,01030.183E,466.0m,4,260,560.0m,122.475,"Flugplatz"
 "Iserlohn Rheiner",,DE,5125.817N,00738.650E,191.0m,4,070,800.0m,123.500,"Flugplatz"


### PR DESCRIPTION
Updated radio frequency of ETSI. Both aeroclubs and also Ingo tower operate on 125.25 MHz.