### PR TITLE
Update Germany.cup

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -609,7 +609,7 @@
 "Nabern Teck",,DE,4836.750N,00928.633E,372.0m,2,140,570.0m,118.325,"Flugplatz"
 "Nannhausen",,DE,4958.217N,00728.733E,381.0m,2,060,560.0m,130.600,"Flugplatz"
 "Nardt",,DE,5127.100N,01412.150E,117.0m,2,080,950.0m,123.000,"Flugplatz"
-"Nastaetten",,DE,5011.883N,00753.333E,363.0m,4,080,1020.0m,126.500,"Flugplatz"
+"Nastaetten",,DE,5011.883N,00753.333E,363.0m,4,080,1020.0m,133.480,"Flugplatz"
 "Nauen Cls",,DE,5237.600N,01254.833E,28.0m,3,100,850.0m,,"Landefeld"
 "Naunheim Maifeld",,DE,5015.500N,00719.933E,195.0m,3,060,180.0m,123.425,"Landefeld"
 "Neresheim",,DE,4844.500N,01019.667E,538.0m,4,080,750.0m,130.125,"Flugplatz"


### PR DESCRIPTION
Radio Frequency of glider field Nassstaedten update to new frequency 133.480.
See: http://www.aero-club-nastaetten.de/index.php/anflug-platzrunde