### PR TITLE
Update Germany.cup

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -525,7 +525,7 @@
 "Lauda Landefeld",,DE,4934.483N,00942.583E,185.0m,3,160,370.0m,,"Landefeld"
 "Lauenbrueck",,DE,5312.467N,00934.400E,29.0m,2,110,600.0m,123.650,"Flugplatz"
 "Laufenselden",,DE,5013.300N,00759.917E,400.0m,4,050,510.0m,134.535,"Flugplatz"
-"Lauf Lillinghof",,DE,4936.317N,01117.017E,544.0m,5,070,450.0m,133.500,"Flugplatz"
+"Lauf Lillinghof","EDQI",DE,4936.317N,01117.017E,544.0m,5,070,450.0m,128.585,"Flugplatz"
 "Laupheim Mil",,DE,4813.200N,00954.617E,540.0m,5,090,1660.0m,122.100,"Flugplatz"
 "Lauterbach",,DE,5041.017N,00924.683E,364.0m,2,060,600.0m,122.175,"Flugplatz"
 "Leibertingen",,DE,4802.683N,00901.833E,833.0m,4,100,940.0m,129.975,"Flugplatz"


### PR DESCRIPTION
Updated radio frequ. for Lauf Lilinghof according to:
https://www.dfs.de/dfs_homepage/de/Services/Customer Relations/Kundenbereich VFR/06.08.2018 - 8,33 kHz-Umstellung/8.33KHz_Frequenzliste_28_02_19.pdf