### PR TITLE
Update Germany.cup

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -553,7 +553,7 @@
 "Luchow Rehbeck",,DE,5301.033N,01108.683E,10.0m,5,150,650.0m,122.500,"Flugplatz"
 "Lunen Lippeweide",,DE,5137.017N,00730.083E,50.0m,4,090,1030.0m,123.505,"Flugplatz"
 "Lueneburg",,DE,5314.900N,01027.483E,49.0m,2,070,980.0m,122.180,"Flugplatz"
-"Luesse",,DE,5208.600N,01240.217E,64.0m,2,060,1020.0m,129.975,"Flugplatz"
+"Luesse","EDOJ",DE,5208.600N,01240.217E,64.0m,2,060,1020.0m,128.755,"Flugplatz"
 "Magdeburg Cochst",,DE,5151.367N,01125.083E,183.0m,5,080,2500.0m,131.125,"Flugplatz"
 "Magdeburg-City",,DE,5204.417N,01137.617E,82.0m,5,090,1000.0m,119.300,"Flugplatz"
 "Mainbullau",,DE,4941.700N,00910.950E,455.0m,5,050,700.0m,122.375,"Flugplatz"


### PR DESCRIPTION
Updated radio frequ. for Luesse according to
https://www.dfs.de/dfs_homepage/de/Services/Customer Relations/Kundenbereich VFR/06.08.2018 - 8,33 kHz-Umstellung/8.33KHz_Frequenzliste_28_02_19.pdf