### PR TITLE
Update Germany.cup

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -613,7 +613,7 @@
 "Nastaetten",,DE,5011.883N,00753.333E,363.0m,4,080,1020.0m,133.480,"Flugplatz"
 "Nauen Cls",,DE,5237.600N,01254.833E,28.0m,3,100,850.0m,,"Landefeld"
 "Naunheim Maifeld",,DE,5015.500N,00719.933E,195.0m,3,060,180.0m,123.425,"Landefeld"
-"Neresheim",,DE,4844.500N,01019.667E,538.0m,4,080,750.0m,130.125,"Flugplatz"
+"Neresheim",,DE,4844.500N,01019.667E,538.0m,4,080,750.0m,126.015,"Flugplatz"
 "Neuweiler Wiese",,DE,4839.300N,00836.500E,654.0m,3,080,250.0m,,"Landefeld"
 "Neubiberg Cls",,DE,4804.383N,01138.283E,576.0m,3,070,2140.0m,,"Landefeld"
 "Neubrandenbu Mil",,DE,5336.133N,01318.367E,70.0m,5,090,2290.0m,119.180,"Flugplatz"


### PR DESCRIPTION
Updated radio frequ for Neresheim according to:
https://www.dfs.de/dfs_homepage/de/Services/Customer Relations/Kundenbereich VFR/06.08.2018 - 8,33 kHz-Umstellung/8.33KHz_Frequenzliste_28_02_19.pdf