### PR TITLE
Update Germany.cup

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -673,7 +673,7 @@
 "Oeventrop Ruhrwi",,DE,5123.767N,00808.667E,241.0m,4,120,440.0m,124.005,"Flugplatz"
 "Offenbuettel Ul",,DE,5410.550N,00922.683E,3.0m,3,140,310.0m,123.425,"Landefeld"
 "Offenburg",,DE,4826.883N,00755.417E,153.0m,5,020,910.0m,119.750,"Flugplatz"
-"Ohlstadt",,DE,4739.467N,01114.033E,655.0m,5,040,880.0m,130.125,"Flugplatz"
+"Ohlstadt",,DE,4739.467N,01114.033E,655.0m,5,040,880.0m,118.930,"Flugplatz"
 "Oldenburg Hatten",,DE,5304.117N,00818.750E,9.0m,2,060,770.0m,118.175,"Flugplatz"
 "Oldenburg Cls",,DE,5310.800N,00809.667E,8.0m,3,100,2110.0m,122.100,"Landefeld"
 "Oppenheim",,DE,4950.467N,00822.550E,86.0m,2,020,800.0m,122.000,"Flugplatz"


### PR DESCRIPTION
Updated radio frequ. for Ohlstadt (listet under Poemetsried) accoring to
https://www.dfs.de/dfs_homepage/de/Services/Customer Relations/Kundenbereich VFR/06.08.2018 - 8,33 kHz-Umstellung/8.33KHz_Frequenzliste_28_02_19.pdf