### PR TITLE
Update Germany.cup

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -739,7 +739,7 @@
 "Rerik Zweedorf",,DE,5404.917N,01138.933E,9.0m,2,080,640.0m,126.500,"Flugplatz"
 "Rheine Bentl Mil",,DE,5217.467N,00723.233E,40.0m,5,090,500.0m,122.100,"Flugplatz"
 "Rheine Eschendor",,DE,5216.600N,00729.533E,41.0m,2,110,920.0m,122.050,"Flugplatz"
-"Rheinstetten",,DE,4858.667N,00820.550E,116.0m,4,020,1030.0m,123.355,"Flugplatz"
+"Rheinstetten",,DE,4858.667N,00820.550E,116.0m,4,020,1030.0m,121.240,"Flugplatz"
 "Riedelbach",,DE,5018.133N,00823.083E,508.0m,4,060,710.0m,119.730,"Flugplatz"
 "Riedlingen",,DE,4808.667N,00928.000E,529.0m,4,040,520.0m,129.975,"Flugplatz"
 "Riesa Goehlis",,DE,5117.583N,01321.433E,98.0m,5,120,1000.0m,122.600,"Flugplatz"


### PR DESCRIPTION
Siehe http://www.lsg-rheinstetten.de/lsgpage/downloads/Platzrunde.pdf
http://www.lsg-rheinstetten.de/index.php/21-neue-frequenz-ab-28-03-2019
Die 'neue' Frequenz scheint in der DAEC Liste wohl falsch angegeben.
Kommentar auf FB: "Am 11.4. wird in der AIP GEN 0-19 der Korrekturhinweis für falsche Einträge auf der neuen ICAO-Karte veröffentlicht. Also lesen und ausdrucken."