### PR TITLE
Airfield Hetzleser Berg changed runway direction

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -400,7 +400,7 @@
 "Herzogenaurach","EDQH",DE,4934.967N,01052.700E,324.0m,5,080,700.0m,134.555,"Flugplatz"
 "Hessisch Lichtenau",,DE,5111.333N,00944.567E,411.0m,4,090,800.0m,123.965,"Segelflug"
 "Hettstadt","EDGH",DE,4947.917N,00950.217E,320.0m,2,090,550.0m,122.430,"Flugplatz"
-"Hetzleser Berg","EDQX",DE,4938.533N,01109.750E,528.0m,5,080,600.0m,123.605,"Flugplatz"
+"Hetzleser Berg","EDQX",DE,4938.533N,01109.750E,528.0m,5,070,600.0m,123.605,"Flugplatz"
 "Heubach","EDTH",DE,4848.183N,00955.667E,433.0m,5,070,750.0m,134.115,"Flugplatz"
 "Hienheim",,DE,4852.683N,01145.633E,397.0m,4,110,540.0m,119.640,"Segelflug"
 "Hildesheim","EDVM",DE,5210.783N,00956.733E,88.0m,5,070,1220.0m,119.640,"Flugplatz"


### PR DESCRIPTION
Due to the earth magnetic field change, our runway direction was changed by the authorities.