### PR TITLE
Updated Ingolstadt radio frequency to new 8.33 spacing

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -444,7 +444,7 @@
 "Imsweiler",,DE,4936.367N,00747.617E,289.0m,3,060,280.0m,130.780,"UL"
 "Ingelfingen Buehlhof","EDGI",DE,4919.300N,00939.817E,421.0m,5,070,480.0m,120.835,"Flugplatz"
 "Ingolstadt Etting",,DE,4848.617N,01125.257E,380.0m,4,100,700.0m,135.090,"Segelflug"
-"Ingolstadt Manching Mil",,DE,4843.250N,01131.814E,366.0m,5,070,2940.0m,125.250,"Flugplatz"
+"Ingolstadt Manching Mil","ETSI",DE,4843.250N,01131.814E,366.0m,5,070,2940.0m,125.255,"Flugplatz"
 "Ippesheim Ul",,DE,4936.583N,01013.533E,297.0m,3,100,350.0m,124.535,"UL"
 "Irsingen",,DE,4902.300N,01030.183E,466.0m,4,260,560.0m,134.135,"Segelflug"
 "Iserlohn Rheinermark",,DE,5125.817N,00738.650E,191.0m,4,070,800.0m,124.465,"Segelflug"


### PR DESCRIPTION
Ingolstadt changed frequency to 8.33 spacing. I am homebased at this airport.
Here is the full NOTAM text:
Q) EDMM/QCACF/IV/B /A /000/999/4842N01132E
A) ETSI
B) 19/12/05 08:00 C) 20/02/28 12:00
E) OPERATING VHF FREQ CHANGED AS FOLLOWS: INGO RADAR 120.600 MHZ CHANGED INTO 120.605 MHZ INGO TRAMON 125.575 MHZ CHANGED INTO 125.580 MHZ INGO TOWER 125.250 MHZ CHANGED INTO 125.255 MHZ