### PR TITLE
Update Germany.cup: remove Obersoellbach

### DIFF
--- a/waypoints/Germany.cup
+++ b/waypoints/Germany.cup
@@ -668,7 +668,6 @@
 "Oberrissdorf","EDUO",DE,5132.600N,01135.683E,224.0m,2,140,500.0m,122.630,"Flugplatz"
 "Oberrot Glashofe",,DE,4900.600N,00938.333E,488.0m,3,100,250.0m,123.425,"Landefeld"
 "Oberschleissheim","EDNX",DE,4814.350N,01133.550E,485.0m,5,080,800.0m,131.130,"Flugplatz"
-"Obersoellbach",,DE,4911.000N,00933.550E,287.0m,3,150,260.0m,123.425,"Landefeld"
 "Ochsenfurt","EDGJ",DE,4940.417N,01004.267E,248.0m,2,100,510.0m,119.990,"Flugplatz"
 "Ochsenhausen",,DE,4803.200N,00954.950E,650.0m,4,080,320.0m,131.260,"Segelflug"
 "Oedheim Heli Mil","EDGO",DE,4914.483N,00914.067E,156.0m,3,180,420.0m,118.410,"Heli"


### PR DESCRIPTION

<img width="1040" alt="Screenshot 2021-03-20 214348" src="https://user-images.githubusercontent.com/7151521/111885017-8651c300-89c5-11eb-893e-817d5526ec62.png">
<!--
Thank you very much for contributing! Please fill out the following
questions to make it easier for us to review your changes.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Obersollbach removed: This "landing field" is actually a helicopter landing pad (see gmaps or https://www.openaip.net/node/152857/node_last_approved). The grass strip is approx. 16 m wide and bordered by trees and an agricultural area. The registered frequency simulates a UL / SF / airfield.

What is the source of the data (for e.g. new frequencies)?
----------------------------------------------------------

see gmaps or https://www.openaip.net/node/152857/node_last_approved
