### PR TITLE
Update Poland.cup

### DIFF
--- a/waypoints/Poland.cup
+++ b/waypoints/Poland.cup
@@ -4,7 +4,7 @@
 "Bielsko Biala",,PL,4948.300N,01900.117E,402.0m,2,040,530.0m,122.700,"Flugplatz"
 "Borsk Mil",,PL,5357.100N,01756.650E,139.0m,5,120,2000.0m,,"Flugplatz"
 "Bydgoszcz",,PL,5305.800N,01758.667E,73.0m,5,080,2510.0m,131.000,"Flugplatz"
-"Bystrzyca Klodzka",,PL,5018.310N01638.460E,380.0m,2,092,450.0m,122.800,"Flugplatz"
+"Bystrzyca Klodzka",,PL,5018.310N,01638.460E,380.0m,2,092,450.0m,122.800,"Flugplatz"
 "Cewice Mil",,PL,5424.967N,01745.800E,153.0m,5,070,2510.0m,124.500,"Flugplatz"
 "Czestochowa Cls",,PL,5053.083N,01912.217E,257.0m,3,080,1990.0m,,"Landefeld"
 "Darlowo",,PL,5424.283N,01621.183E,3.0m,5,040,590.0m,124.500,"Flugplatz"


### PR DESCRIPTION
Added Bystrzyca Klodzka
Source: https://www.openaip.net/node/158570
"Bystrzyca Klodzka",,PL,5018.310N01638.460E,380.0m,2,092,450.0m,122.800,"Flugplatz"

<!--
Thank you very much for contributing! Please fill out the following
questions to make it easier for us to review your changes.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Please enter a summary of the changes.
-->

What is the source of the data (for e.g. new frequencies)?
----------------------------------------------------------

<!--
Please provide direct URLs if possible.
-->
