### PR TITLE
Update Czech_Republic.cup

### DIFF
--- a/waypoints/Czech_Republic.cup
+++ b/waypoints/Czech_Republic.cup
@@ -26,7 +26,7 @@
 "Brnenec",,CZ,4937.333N,01631.467E,550.0m,1,,,,"Nadrazi/Station"
 "Bruntal",,CZ,4959.617N,01728.467E,587.0m,1,,,,"Nadrazi/Station"
 "Buchlov",,CZ,4906.417N,01718.800E,450.0m,16,,,,"Hrad/Castle"
-"Bucovice",,CZ,5012.493N,01712.475E,308.0m,3,190,,,"Bucovice Outlanding Field"
+"Bucovice",,CZ,5012.493N,01712.475E,486.0m,3,190,,,"Bucovice Outlanding Field"
 "Bulovka",,CZ,5057.900N,01507.100E,308.0m,17,,,,"Krizovatka/Crossroads"
 "Bylnice",,CZ,4904.033N,01800.867E,314.0m,1,,,,"Nadrazi/Station"
 "Bystrice.N.Per",,CZ,4931.350N,01615.683E,558.0m,1,,,,"Namesti/Square, Bystrice n.Pernstejnem"


### PR DESCRIPTION
Added Bucovice Outlanding field
Source: https://drive.google.com/file/d/1uuQWB6RD8f1xIdJwrZPkg86BX8yImx7Z/view Slide 21
"Bucovice",,CZ,5012.493N,01712.475E,308.0m,3,190,,,"Bucovice Outlanding Field"

Deleted Bayreuth as a Waypoint

<!--
Thank you very much for contributing! Please fill out the following
questions to make it easier for us to review your changes.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Please enter a summary of the changes.
-->

What is the source of the data (for e.g. new frequencies)?
----------------------------------------------------------

<!--
Please provide direct URLs if possible.
-->
