### PR TITLE
feat: Enforce that waypoints/country filenames are valid ISO3166.alpha2.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,12 @@ jobs:
           echo "WPBC_DST=waypoints" >> $GITHUB_ENV
           # Waypoints-special source:
           echo "WPS_SRC=waypoints-special" >> $GITHUB_ENV
+
+      - name: "Check waypoints/country"
+        run: |
+          set -e
+          ./scripts/check_waypoints_country.py ${{ env.WPBC_SRC }}
+
       - name: "Create the release artefacts"
         run: |
           ./scripts/generate-web-waypoints-index.py  ${{ env.WPBC_SRC }}  ${{ env.WPBC_DST }}
@@ -35,11 +41,10 @@ jobs:
       - name: "Concatenate all waypoints to xcsoar-waypoints.cup"
         run: |
           cat ${{ env.WPBC_SRC }}/*.cup | sort -b > ${{ env.WPBC_DST }}/xcsoar_waypoints.cup
-          
-      - name: "Check Waypoints"
+
+      - name: "Check waypoints/special"
         run: |
           set -e
-          for each in ${{ env.WPBC_SRC }}/*.cup ; do python ./scripts/check-waypoints "${each}" ; done
           for each in ${{ env.WPS_SRC }}/*.cup ; do python ./scripts/check-waypoints "${each}" ; done
 
       - name: "Install SSH key"

--- a/scripts/check_waypoints_country.py
+++ b/scripts/check_waypoints_country.py
@@ -1,0 +1,57 @@
+#!/bin/env python3
+"""Ensure that waypoints/countries are named correctly, and pass an Aerofiles check."""
+
+from pathlib import Path
+import sys
+
+from aerofiles.seeyou.reader import Reader as CupReader
+from aerofiles import errors
+
+from iso3166 import countries
+
+
+def is_valid_cup(filename: Path) -> bool:
+    """Return True if filename is in a valid SeeYou .cup format, else false."""
+    cup = CupReader()
+    try:
+        cup.read(open(filename))
+    except errors.ParserError:
+        print(f'INVALID SeeYou .cup format: {filename}')
+        return False
+    print(f'Valid .cup format: {filename}')
+    return True
+
+
+def is_name_country_code(filename: Path) -> bool:
+    """Return True if filename.stem is a valid two-letter country code (ISO 3166-1 alpha-2), else return False."""
+    name = filename.stem
+
+    try:
+        country = countries.get(name)
+    except KeyError:
+        print(f'INVALID ISO 3166-1 alpha-2 country code: {name} ({filename})')
+        return False
+
+    if country.alpha2.lower() != name.lower():
+        # Valid country/code, but not alpha2.
+        print(f'INVALID two-letter ISO 3166-1 alpha-2 country code: {name} ({filename})')
+        return False
+    print(f'Valid two-letter country code: {name} ({filename})')
+    return True
+
+
+def main(in_dir: Path) -> int:
+    """Check all the .cup files in the in_dir."""
+    ok = True
+    for p in sorted(in_dir.glob('*.cup')):
+        ok = is_name_country_code(p) and ok
+        ok = is_valid_cup(p) and ok
+    return ok
+
+
+if __name__ == '__main__':
+    wp_dir = Path(sys.argv[1])
+
+    if main(wp_dir):
+        sys.exit(0)
+    sys.exit(1)


### PR DESCRIPTION
This will allow us to:

1. Remove the migration code in scripts/generate-web-waypoints-index.py (and the pytz dependency).
2. Provide a basis for doing the similar autogen, etc. for `waypoints-special` (and ``maps?).
3. Generate the `area` tag in the waypoints/country manifests with confidence. 
