### PR TITLE
Towards Flexible Deploys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: "Check, generate, and deploy xcsoar-data-content"
+name: "PROD: Check, generate, and deploy (if push to master) xcsoar-data-content"
 
 on: 
   push:
@@ -9,70 +9,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    #environment: production
 
     steps:
       - uses: actions/checkout@v2
-      
-      - name: "SETUP: Dependencies"
-        uses: BSFishy/pip-action@v1
-        with:
-          packages: |
-            aerofiles
-            iso3166
 
-      - name: "SETUP: variables"
+      - name: "PROD: Build"
         run: |
-          # Waypoint-by-country:
-          echo "WPBC_SRC=waypoints" >> $GITHUB_ENV
-          echo "WPBC_DST=waypoints" >> $GITHUB_ENV
-          # Waypoints-special source:
-          echo "WPS_SRC=waypoints-special" >> $GITHUB_ENV
+          ./scripts/build.bash
 
-
-      - name: "CHECK: waypoints/country"
+      - name: "PROD: Deploy"
         run: |
-          set -e
-          ./scripts/check_waypoints_country.py ${{ env.WPBC_SRC }}
-
-      - name: "CHECK: waypoints/special"
-        run: |
-          set -e
-          for each in ${{ env.WPS_SRC }}/*.cup ; do python ./scripts/check-waypoints "${each}" ; done
-
-
-      - name: "GENERATE: Release artefacts"
-        run: |
-          ./scripts/generate-web-waypoints-index.py  ${{ env.WPBC_SRC }}  ${{ env.WPBC_DST }}
-
-      - name: "GENERATE: Concatenate all waypoints to xcsoar-waypoints.cup"
-        run: |
-          cat ${{ env.WPBC_SRC }}/*.cup | sort -b > ${{ env.WPBC_DST }}/xcsoar_waypoints.cup
-
-
-      - name: "DEPLOY: Install SSH key"
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.DEPLOY_KEY }}
-          known_hosts: 'ffoooooooobar'
-        if: ${{ github.event_name == 'push' }}
-
-      - run: ssh-keyscan -p ${{ secrets.DEPLOY_PORT }} ${{ secrets.DEPLOY_HOST}} > ~/.ssh/known_hosts 
-        if: ${{ github.event_name == 'push' }}
-
-      - name: "DEPLOY: To repository"
-        run: |
-          umask 077
-          echo "${DEPLOY_KEY}" > ~/id_rsa
-          # Waypoints-by-country: originals:
-          rsync -av -e "ssh -p ${DEPLOY_PORT} -i ~/id_rsa" ${{ env.WPBC_SRC }}/ ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/waypoints/ --delete
-
-          # TODO: Waypoints-by-country: generated artefacts:
-          #rsync -av -e "ssh -p ${DEPLOY_PORT} -i ~/id_rsa" ${{ env.WPBC_DST }}/ ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/waypoints/generated/ --delete
-
-          rsync -av -e "ssh -p ${DEPLOY_PORT} -i ~/id_rsa" ${{ env.WPS_SRC }}/ ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/waypoints-special/ --delete
-          rsync -av -e "ssh -p ${DEPLOY_PORT} -i ~/id_rsa" ./airspaces/ ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/airspaces/ --delete
-        shell: bash
-        if: ${{ github.event_name == 'push' }}
+          ./scripts/deploy.bash
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/scripts/build.bash
+++ b/scripts/build.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Verify integrity and genereate artefacts required by http://download.xcsoar.org/.
+
+# Halt on errors:
+set -e
+# Echo commands:
+set -x
+
+# Install dependencies:
+pip3 install -U aerofiles
+pip3 install -U iso3166
+
+# CHECK: waypoints/country
+./scripts/check_waypoints_country.py waypoints
+
+# CHECK: waypoints/special
+for each in waypoints-special/*.cup ; do python ./scripts/check-waypoints "${each}" ; done
+
+# GENERATE: Release artefacts
+./scripts/generate-web-waypoints-index.py  waypoints waypoints
+
+# GENERATE: Concatenate all waypoints to xcsoar-waypoints.cup
+cat waypoints/*.cup | sort -b > waypoints/xcsoar_waypoints.cup

--- a/scripts/deploy.bash
+++ b/scripts/deploy.bash
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Deploy assets created by build.bash to DEPLOY_HOST.
+
+# Required environment variables:
+#   DEPLOY_KEY
+#   DEPLOY_USER
+#   DEPLOY_HOST
+#   DEPLOY_PATH
+#   DEPLOY_PORT
+
+# Halt on errors:
+set -e
+# Echo commands:
+set -x
+
+if [[ -z ${DEPLOY_KEY} || -z ${DEPLOY_USER} || -z ${DEPLOY_HOST} || -z ${DEPLOY_PATH} || -z ${DEPLOY_PORT} ]]; then
+  echo 'One or more variables are undefined. Exiting.'
+  exit 1
+fi
+
+
+# SSH identity_file (DO NOT inadvertently rsync to production!)
+ID_FILE="ssh_deploy_key"
+
+KH_FILE="known_hosts"
+
+# Protect this private key file:
+umask 077
+# Hide only this command:
+set +x
+echo "${DEPLOY_KEY}" > ${ID_FILE}
+set -x
+
+ssh-keyscan -p "${DEPLOY_PORT}" "${DEPLOY_HOST}" > ${KH_FILE}
+
+SSH_CMD="ssh -p ${DEPLOY_PORT} -i ${ID_FILE} -o UserKnownHostsFile=${KH_FILE}"
+
+rsync --delete -avze "${SSH_CMD}" ./waypoints/         "${DEPLOY_USER}"@"${DEPLOY_HOST}":"${DEPLOY_PATH}"/waypoints/
+rsync --delete -avze "${SSH_CMD}" ./waypoints-special/ "${DEPLOY_USER}"@"${DEPLOY_HOST}":"${DEPLOY_PATH}"/waypoints-special/
+rsync --delete -avze "${SSH_CMD}" ./airspaces/         "${DEPLOY_USER}"@"${DEPLOY_HOST}":"${DEPLOY_PATH}"/airspaces/
+
+# Cleanup
+rm -f ${KH_FILE} ${ID_FILE}


### PR DESCRIPTION
1. This paves the way for personal development environments.  I.e. `build.bash` will run successfully on every fork, on every  branch, for every commit. `deploy.bash` will run on `push` to `master` (as it is presently), **and** if one has defined one's own personal `development` GH Environment for every commit.

1. The Bash deploy script is independent of GitHub.

1. The Bash build script is independent of GitHub, and can be run while developing (before commit, before push, before PR, etc.).

1. rsync: compresses transit diffs

1. Removed pointless `shimataro/ssh-key-action@v2`

1. Removed pointless `BSFishy/pip-action@v1`

1. rsync: supports different identity key types, not just RSA.

1. More readable.