### PR TITLE
Ability to check validity of various repository URLs.

### DIFF
--- a/.github/workflows/check_repo_urls.yml
+++ b/.github/workflows/check_repo_urls.yml
@@ -1,0 +1,21 @@
+name: "Repository URL checker"
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # 03h43Z everyday
+    - cron: '43 3 * * *'
+
+jobs:
+  check_urls:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Check URLs"
+        run: |
+          pip install -U requests
+          ./scripts/check_urls.py

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -1,0 +1,57 @@
+#!/bin/env python3
+"""Check if all the repository URLs are working."""
+
+import sys
+import requests
+from typing import List
+from pathlib import Path
+
+
+def get_urls_from_www(repo_url: str) -> List[str]:
+    """Extract all the URLs after "uri=" at repo_url."""
+    repo_req = requests.get(repo_url)
+
+    urls = []
+    for line in repo_req.iter_lines():
+        decoded_line = line.decode("utf-8")
+        if decoded_line.startswith("uri="):
+            urls.append(decoded_line[4:])
+    return urls
+
+
+def get_urls_from_file(repo_file: Path) -> List[str]:
+    """Extract all the URLs after "uri=" in repo_file."""
+    urls = []
+    with repo_file.open() as in_file:
+        for line in in_file:
+            single_line = line.strip()
+            if single_line.startswith("uri="):
+                urls.append(single_line[4:].strip())
+    return urls
+
+
+def check_urls(urls: List[str]) -> bool:
+    """Check (by an HTTP HEAD request) the URLs in urls."""
+    rv = True
+    for i, url in enumerate(urls):
+        req = requests.head(url, allow_redirects=True)
+        if req.status_code == requests.codes.ok:
+            print(f"{i}\tpass {req.status_code} {url}")
+        else:
+            print(f"{i}\tFAIL {req.status_code} {url}\t!!!")
+            rv = False
+    return rv
+
+
+if __name__ == "__main__":
+
+    repository = "http://download.xcsoar.org/repository"
+
+    url_list = get_urls_from_www(repo_url=repository)
+    # url_list = get_urls_from_file(repo_file=Path("repository"))
+    if check_urls(urls=url_list):
+        print("PASS: All URIs downloaded successfully.")
+        sys.exit(0)
+
+    print("FAIL: some/all URIs could not be downloaded.")
+    sys.exit(1)


### PR DESCRIPTION
### The purpose of this change

This PR brings the functionality (in Python) to check the existence of the `uri`s used in this repo, the repository repo, and http://download.xcsoar.org/repository itself (this PR's source).   As such, it is the first step towards closing: https://github.com/XCSoar/xcsoar-data-repository/issues/216

The `uri`s are checked on push, pull_requests, and on a daily cron schedule (since there are many external `uri`s with independent failure modes.

