### PR TITLE
Update DE.cup

### DIFF
--- a/data/content/waypoint/country/DE.cup
+++ b/data/content/waypoint/country/DE.cup
@@ -623,7 +623,7 @@
 "Neubiberg X",,DE,4804.383N,01138.283E,576.0m,3,070,2140.0m,,"Landefeld"
 "Neubrandenburg","EDBN",DE,5336.133N,01318.367E,70.0m,5,090,2290.0m,119.180,"Flugplatz"
 "Neuburg Egweil","EDNJ",DE,4846.917N,01112.917E,412.0m,2,080,640.0m,132.005,"Flugplatz"
-"Neuburg Mil",,DE,4842.667N,01112.700E,381.0m,5,090,2450.0m,122.100,"Flugplatz"
+"Neuburg Mil","ETSN",DE,4842.667N,01112.700E,381.0m,5,090,2450.0m,129.855,"Flugplatz"
 "Neuenstadt A Koc",,DE,4914.567N,00919.033E,168.0m,3,100,250.0m,123.425,"Landefeld"
 "Neuhardenberg","EDON",DE,5236.783N,01414.567E,12.0m,5,080,2400.0m,119.130,"Flugplatz"
 "Neuhaus Sumte",,DE,5317.383N,01054.267E,8.0m,3,130,300.0m,,"Landefeld"


### PR DESCRIPTION
Added ICAO Identifier for Neuburg Mil and corrected radio frequnency.
Data Source: OpenAIP
Remark: I fly out of Ingolstadt occationally and can confirm that the freq and ICAO identifier of ETSN are correct.

<!--
Thank you very much for contributing! Please fill out the following
questions to make it easier for us to review your changes.
-->

# The purpose of this change

<!--
Please enter a summary of the changes.
-->

# The source of the data (for e.g. new frequencies)

<!--
Please provide direct URLs if possible.
-->
