### PR TITLE
Airspace: add Australia HG/PG SiteGuide

### DIFF
--- a/data/remote/airspace/region/Australia_HGPG_SiteGuide.txt.json
+++ b/data/remote/airspace/region/Australia_HGPG_SiteGuide.txt.json
@@ -1,0 +1,1 @@
+{"uri": "https://siteguide.org.au/siteGuide.OpenAir.txt"}


### PR DESCRIPTION
This airspace adds Recommended/Restricted/Prohibited LZs and dangers/obstacles (like power lines), for the most active flying sites for hang gliders and paragliders in Australia.
The airspace file is managed by several clubs members and it is continuously updated, due the continuous changes and agreements with the land owners.

Source: https://siteguide.org.au/

This is the same work previously merged in the https://github.com/XCSoar/xcsoar-data-repository/pull/218