### PR TITLE
Switzerland-airspace again from soaringweb

### DIFF
--- a/data/remote/airspace/country/Switzerland_Airspace.txt.json
+++ b/data/remote/airspace/country/Switzerland_Airspace.txt.json
@@ -1,0 +1,1 @@
+{"uri": "https://www.segelflug.ch/wp-content/uploads/2021/06/SFVS-FSVV_CH-Airspace_MAY2021.txt"}


### PR DESCRIPTION
# The purpose of this change

Swiss airspace from Swiss Gliding Association instead of our own directory.

# The source of the data (for e.g. new frequencies)

https://soaringweb.org/Airspace/CH/SFVS-FSVV_Airspace_2021.txt