### PR TITLE
Germany_Airspace.txt: Update to the recent version from the DAeC site

### DIFF
--- a/data/remote/airspace/country/Germany_Airspace.txt.json
+++ b/data/remote/airspace/country/Germany_Airspace.txt.json
@@ -1,1 +1,1 @@
-{"uri": "https://www.daec.de/fileadmin/user_upload/files/2021/Fachbereiche/Luftraum_und_Flugbetrieb/2021_05_Airspace_Germany.txt"}
+{"uri": "https://www.daec.de/fileadmin/user_upload/files/2022/Fachbereiche/Luftraum_und_Flugbetrieb/2022_03b_DAeC_Airspace_Germany2022.txt"}


### PR DESCRIPTION
The recent version of airspaces is valid from 24-Mar-2022.

<!--
Thank you very much for contributing! Please fill out the following
questions to make it easier for us to review your changes.
-->

# Pull Request

## The purpose of this change

<!--
Please enter a summary of the changes.
-->

## The source of the data (for e.g. new frequencies)

<!--
Please provide direct URLs if possible.
-->
