### PR TITLE
Update NZ airspace to Dec 2021

### DIFF
--- a/data/remote/airspace/country/New_Zealand_Airspace.txt.json
+++ b/data/remote/airspace/country/New_Zealand_Airspace.txt.json
@@ -1,0 +1,1 @@
+{"uri": "https://gliding.co.nz/wp-content/uploads/2021/12/NZ-Airspace-Dec-2021-v5.txt"}

--- a/data/remote/airspace/country/New_Zealand_Airspace_NI.txt.json
+++ b/data/remote/airspace/country/New_Zealand_Airspace_NI.txt.json
@@ -1,1 +1,0 @@
-{"uri": "http://gliding.co.nz/wp-content/uploads/files/NIAirspace9Nov2017.txt"}

--- a/data/remote/airspace/country/New_Zealand_Airspace_SI.txt.json
+++ b/data/remote/airspace/country/New_Zealand_Airspace_SI.txt.json
@@ -1,1 +1,0 @@
-{"uri": "http://gliding.co.nz/wp-content/uploads/files/SI%20Airspace%20eff%207%20Nov19%20OpenAir.txt"}


### PR DESCRIPTION
Prior North Island file is dated 2017
Prior South Island file is dated 2019
Prior SI had some invalid definitions

<!--
Thank you very much for contributing! Please fill out the following
questions to make it easier for us to review your changes.
-->

# Pull Request

## The purpose of this change
Update the New Zealand airspace file with the most recent from
the Gliding New Zealand website.

This change removes the separate North Island and South Island airspace
files and replaces them with the single combined file.

The previous South Island airspace had one or more invalid defintions
which made the boundaries of some sections visibly wrong.
<!--
Please enter a summary of the changes.
-->

## The source of the data (for e.g. new frequencies)
Source is https://gliding.co.nz/wp-content/uploads/2021/12/NZ-Airspace-Dec-2021-v5.txt
<!--
Please provide direct URLs if possible.
-->
