### PR TITLE
CZ.cup - Remove outdated landing strips pt.2

### DIFF
--- a/data/content/waypoint/country/CZ.cup
+++ b/data/content/waypoint/country/CZ.cup
@@ -747,7 +747,6 @@ name,code,country,lat,lon,elev,style,rwdir,rwlen,freq,desc
 "ULTREB",,CZ,4900.700N,01540.450E,459.0m,3,0,0.0m,,"Nouzova plocha"
 "ULTREM",,CZ,4951.500N,01532.500E,317.0m,3,0,0.0m,,"Nouzova plocha"
 "ULTRUJ",,CZ,5033.067N,01553.133E,459.0m,3,0,0.0m,,"Nouzova plocha"
-"ULTYNV",,CZ,4914.183N,01427.233E,450.0m,3,0,0.0m,,"Nouzova plocha"
 "ULUJAN",,CZ,4953.317N,01508.250E,465.0m,3,0,0.0m,,"Nouzova plocha"
 "ULULIB",,CZ,5025.583N,01526.917E,286.0m,3,0,0.0m,,"Nouzova plocha"
 "ULVALD",,CZ,5027.117N,01524.517E,300.0m,3,0,0.0m,,"Nouzova plocha"


### PR DESCRIPTION
Following up on PR #252, another suggestion for landing strip removal has been made on the CZ gliding forum:
https://www.gliding.cz/forum/viewtopic.php?f=1&t=7132

"The same must be done with the area near Týn n. Vltava! The area has been used as a landfill for almost 15 years, it is definitely not a backup area."