### PR TITLE
Update Sweden airspace

### DIFF
--- a/data/remote/airspace/country/Sweden_Airspace.txt.json
+++ b/data/remote/airspace/country/Sweden_Airspace.txt.json
@@ -1,1 +1,1 @@
-{"uri": "https://soaringweb.org/Airspace/SE/Sweden-Airspace-2022-May-19.txt"}
+{"uri": "https://soaringweb.org/Airspace/SE/Sweden-Airspace-2022-June-16.txt"}


### PR DESCRIPTION
# Pull Request

## The purpose of this change

Updates Swedish airspace to the newest version. The June 14 file is currently only available on Soaringweb. I think it's just a matter of Segelflyget not having updated their website with it yet. I think we can go ahead with this PR regardless.

## The source of the data (for e.g. new frequencies)

Soaringweb.