### PR TITLE
Update French airspace file location

### DIFF
--- a/data/remote/airspace/country/France_Airspace.txt.json
+++ b/data/remote/airspace/country/France_Airspace.txt.json
@@ -1,1 +1,1 @@
-{"uri": "https://soaringweb.org/Airspace/FR/France_22-6.txt"}
+{"uri": "https://planeur-net.github.io/airspace/france.txt"}


### PR DESCRIPTION
The French airspace file on openair format is maintained by a small community for French glider pilots. The file was previously "manually" updated on several websites, including soaringweb.org
This file is now maintained within a github repository, and automatically published to www.planeur.net (The French gliding website). The github link to access the file should now be used. It will allow XCSoar users to make sure that they can always download the latest airspace from the application.

<!--
Thank you very much for contributing! Please fill out the following
questions to make it easier for us to review your changes.
-->

# Pull Request

## The purpose of this change
The French airspace file is now maintained and kept up to date via github. The Url to download the file should be changed.

## The source of the data (for e.g. new frequencies)
XCSoar should now be using the github provided URL
