### PR TITLE
OpenAir-Datei Lufträume Österreich XCSoar: (MTA) Update

### DIFF
--- a/data/remote/airspace/country/Austria_Airspace.txt.json
+++ b/data/remote/airspace/country/Austria_Airspace.txt.json
@@ -1,3 +1,3 @@
 {
-  "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_2020-12-03_xcsoar_2020-10-22_0710894.txt"
+  "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_mta_2023-01-04_080178.txt"
 }


### PR DESCRIPTION
Effective date: 23 FEB 2023

<!--
Thank you very much for contributing! Please fill out the following
questions to make it easier for us to review your changes.
-->

# Pull Request

## The purpose of this change
XCSoar can't download the current AT OpenAir file 
This PR updates the url to the most current valid OpenAir file


## The source of the data (for e.g. new frequencies)
https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_mta_2023-01-04_080178.txt
[All scheduled OpenAir Luftraumstruktur data](https://www.austrocontrol.at/jart/prj3/ac/main.jart?rel=de&content-id=1420599223551)

Was reported [here](https://forum.xcsoar.org/viewtopic.php?f=2&t=4178)

