### PR TITLE
OpenAir-Datei Lufträume Österreich XCSoar: Update to all airspace

### DIFF
--- a/data/remote/airspace/country/Austria_Airspace.txt.json
+++ b/data/remote/airspace/country/Austria_Airspace.txt.json
@@ -1,3 +1,3 @@
 {
-  "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_2020-12-03_xcsoar_2020-10-22_0710894.txt"
+  "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_2023-01-04_0801253.txt"
 }


### PR DESCRIPTION
Effective date: 23 FEB 2023

# Pull Request

## The purpose of this change
The current AT OpenAir file comtains olnly  österreichischen militärischen Trainingsgebieten (MTAs) airspace.
This PR updates the url to the most current valid OpenAir file that contains all airspace


## The source of the data (for e.g. new frequencies)
https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_2023-01-04_0801253.txt


