### PR TITLE
Update OpenAir Austrian Airspace, Effective date: 23 FEB 2023

### DIFF
--- a/data/remote/airspace/country/Austria_Airspace.txt.json
+++ b/data/remote/airspace/country/Austria_Airspace.txt.json
@@ -1,3 +1,3 @@
 {
-  "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_mta_2023-01-04_080178.txt"
+  "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_2023-01-04_0801253.txt"
 }


### PR DESCRIPTION
Effective date: 23 FEB 2023

# Pull Request

## The purpose of this change
The current AT OpenAir file contains only österreichischen militärischen Trainingsgebieten (MTAs) airspace.
This PR updates the url to the most current valid OpenAir file that contains all airspace


## The source of the data (for e.g. new frequencies)
https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_2023-01-04_0801253.txt


