### PR TITLE
New Sweden airspace file as of 2023-03-23

### DIFF
--- a/data/remote/airspace/country/Sweden_Airspace.txt.json
+++ b/data/remote/airspace/country/Sweden_Airspace.txt.json
@@ -1,3 +1,3 @@
 {
-  "uri": "https://soaringweb.org/Airspace/SE/sverige-luftrum-2022-rev4.txt"
+  "uri": "https://soaringweb.org/Airspace/SE/Sweden-Airspace-2023-March-23.txt"
 }


### PR DESCRIPTION
# Pull Request

## The purpose of this change

Update Swedish airspace file.

## The source of the data (for e.g. new frequencies)

Swedish Soaring Federation's website lists this file at (a temporary URL) https://segelflyget.se/grenar/segelflyg/segelflyget/verksamhet/luftrum , but as usual we grab it from Soaringweb :-)