### PR TITLE
Swiss Airspace and eDABS: update uri

### DIFF
--- a/data/remote/airspace/country/CH-ASP-DABS-SegelflugCH.txt.json
+++ b/data/remote/airspace/country/CH-ASP-DABS-SegelflugCH.txt.json
@@ -1,4 +1,4 @@
 {
   "description": "Switzerland Airspace with eDABS from Segeflug.ch",
-  "uri": "https://www.segelflug.ch/wp-content/uploads/2023/04/SFVS-FSVV_CH-Airspace23_eDABS_APR.txt"
+  "uri": "https://www.segelflug.ch/wp-content/uploads/2023/04/SFVS-FSVV_CH-Airspace23_eDABS_APR2.txt"
 }

--- a/data/remote/airspace/country/CH-ASP-National-SegelflugCH.txt.json
+++ b/data/remote/airspace/country/CH-ASP-National-SegelflugCH.txt.json
@@ -1,4 +1,4 @@
 {
   "description": "Switzerland Airspace from Segeflug.ch",
-  "uri": "https://www.segelflug.ch/wp-content/uploads/2023/04/SFVS-FSVV_CH-Airspace23_Full_APR.txt"
+  "uri": "https://www.segelflug.ch/wp-content/uploads/2023/04/SFVS-FSVV_CH-Airspace23_Full_APR2.txt"
 }


### PR DESCRIPTION
# Pull Request
Swiss Airspace and eDABS: update uri

## The purpose of this change
Outdated uri

## The source of the data (for e.g. new frequencies)
https://www.segelflug.ch/safety-und-luftraum/luftraum-ii/luftraumdateien/

