### PR TITLE
Add waypoint cup file for the famous French Alps Outlanding areas booklet

### DIFF
--- a/data/remote/waypoint/region/FR-WPT-guide-des-aires-de-securite-Alps.cup.json
+++ b/data/remote/waypoint/region/FR-WPT-guide-des-aires-de-securite-Alps.cup.json
@@ -1,0 +1,4 @@
+{
+  "description": "France Alps Guides des Aires de Securite. From the well know booklet by CRVVPACA, CRVVRA, FFVP  ",
+  "uri": "https://planeur-net.github.io/outlanding/guide_aires_securite.cup"
+}


### PR DESCRIPTION
This is the cup file for the well know booklet: Outlanding Areas for the French Alps.
In French: Guide des Aires de Securite dans les Alpes

This is fully approved by the Author indicated at the back of the booklet. 
