### PR TITLE
Update Sweden airspace

### DIFF
--- a/data/remote/airspace/country/SE-ASP-National-SoaringWeb.txt.json
+++ b/data/remote/airspace/country/SE-ASP-National-SoaringWeb.txt.json
@@ -1,5 +1,5 @@
 {
   "description": "Sweden Airspace from SoaringWeb.org",
-  "update": "2024-06-13",
-  "uri": "https://soaring.silentflight.ca/Airspace/SE/Sweden-Airspace-2024-June-13.txt"
+  "update": "2024-08-08",
+  "uri": "https://soaring.silentflight.ca/Airspace/SE/Sweden-Airspace-2024-August-08.txt"
 }


### PR DESCRIPTION
@lordfolken I noticed that before this change, the URL to the old file was using `soaring.silentflight.ca` instead of `soaringweb.org`, is there any particular reason or is it still fine to use `soaringweb.org`?