### PR TITLE
Update Finland and Hungary airspace

### DIFF
--- a/data/remote/airspace/country/FI-ASP-National-SoaringWeb.txt.json
+++ b/data/remote/airspace/country/FI-ASP-National-SoaringWeb.txt.json
@@ -1,4 +1,5 @@
 {
   "description": "Finland Airspace from SoaringWeb.org",
-  "uri": "https://soaring.silentflight.ca/Airspace/FI/finland_airspace_200228.txt"
+  "update": "2024-06-25",
+  "uri": "https://soaring.silentflight.ca/Airspace/FI/FIN2024.txt"
 }

--- a/data/remote/airspace/country/HU-ASP-National-SoaringWeb.txt.json
+++ b/data/remote/airspace/country/HU-ASP-National-SoaringWeb.txt.json
@@ -1,5 +1,5 @@
 {
   "description": "Hungary Airspace from SoaringWeb.org",
-  "update": "2024-04-28",
-  "uri": "https://soaring.silentflight.ca/Airspace/HU/HunSUA2024_v1_openair.txt"
+  "update": "2024-07-04",
+  "uri": "https://soaring.silentflight.ca/Airspace/HU/HunSUA2024_v2.txt"
 }


### PR DESCRIPTION
@lordfolken Like in #404 I noticed that before this change, the URL to the old file was using soaring.silentflight.ca instead of soaringweb.org, is there any particular reason or is it still fine to use soaringweb.org?

This PR was due to the failed link checks action. However, there was one link to http://www.openaip.net/xcsoar_export/world_hot.cup that I could not find a solution to. Does anyone know anything about it?

Otherwise (if we don't have any particular contacts to ping) I could contact OpenAIP to see if they can help. It's just that I don't know anything about the background for this seemingly XCSoar-custom export file.