### PR TITLE
Remove reference to non-existent OpenAIP waypoint file

### DIFF
--- a/data/remote/waypoint/global/OpenAIP-Hotspots.cup.json
+++ b/data/remote/waypoint/global/OpenAIP-Hotspots.cup.json
@@ -1,3 +1,0 @@
-{
-  "uri": "http://www.openaip.net/xcsoar_export/world_hot.cup"
-}


### PR DESCRIPTION
As per https://github.com/XCSoar/xcsoar-data-content/pull/405#issuecomment-2276800651 , these hotspots are now in the OpenAIP files and are instead being merged in script/build/xcsoar-openaip-generate-all-cup.py.