### PR TITLE
Update German airspace DAEC

### DIFF
--- a/data/remote/airspace/country/DE-ASP-National-DAEC.txt.json
+++ b/data/remote/airspace/country/DE-ASP-National-DAEC.txt.json
@@ -1,5 +1,5 @@
 {
   "description": "Airspace Germany from DAEC",
-  "update": "2025-03-20",
-  "uri": "https://www.daec.de/media/files/Dateien/Fachbereiche/Luftraum_und_Flugsicherheit/2025_03_Airspace_Germany_DAeC.txt"
+  "update": "2025-06-06",
+  "uri": "https://www.daec.de/media/files/Dateien/Fachbereiche/Luftraum_und_Flugsicherheit/2025_06_Airspace_Germany_DAeC.txt"
 }


### PR DESCRIPTION
Old URL recently became outdated and is not functional anymore.