### PR TITLE
fix(ci): SoaringWeb sync — fix create-pull-request git 400

### DIFF
--- a/.github/workflows/soaringweb_airspace_pr.yml
+++ b/.github/workflows/soaringweb_airspace_pr.yml
@@ -18,7 +18,10 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false avoids duplicate Authorization with create-pull-request (git 400)
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -44,6 +47,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
+          token: ${{ github.token }}
           commit-message: "chore(airspace): refresh SoaringWeb OpenAir URIs"
           title: "chore(airspace): refresh SoaringWeb OpenAir URIs"
           body-path: pr-body.md


### PR DESCRIPTION
## Problem

The **SoaringWeb airspace URI sync** workflow failed at **Create Pull Request** with:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/XCSoar/xcsoar-data-content/': The requested URL returned error: 400
```

(`actions/checkout` persisted credentials while `peter-evans/create-pull-request` also set `http.extraheader`, so Git sent two Authorization headers.)

## Fix

- `checkout`: `persist-credentials: false`
- `create-pull-request`: `token: ${{ github.token }}` so pushes use a single credential path

See [create-pull-request usage](https://github.com/peter-evans/create-pull-request#usage).

After merge, re-run **Actions → SoaringWeb airspace URI sync (PR)** to confirm.