### PR TITLE
data/remote/airspace/country/AT - remove dead link

### DIFF
--- a/data/remote/airspace/country/AT-ASP-National-SoaringWeb.txt.json
+++ b/data/remote/airspace/country/AT-ASP-National-SoaringWeb.txt.json
@@ -1,4 +1,0 @@
-{
-  "description": "Austria Airspace from SoaringWeb.org",
-  "uri": "https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_2023-01-04_0801253.txt"
-}


### PR DESCRIPTION
- the URL for https://www.austrocontrol.at/jart/prj3/ac/data/dokumente/austria_acg_airspaces_20230223_xcsoar_2023-01-04_0801253.txt returns a 404

Not sure if removing the file is the best way to go about things, but:
- The URL is dead
-  Looking at https://www.austrocontrol.at/en/pilots/pre-flight_preparation/aim_products/airspace_structure, I've only been able to find this [OpenAir file Airspaces Austria](https://www.austrocontrol.at/en/pilots/pre-flight_preparation/aim_products/data/dokumente/austria_acg_airspaces_20260219_2026-01-07_0701409.zip), which is a zip file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Austria airspace source configuration from the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->