### PR TITLE
Update FI+ZA ASP-National-SoaringWeb.txt.json

### DIFF
--- a/data/remote/airspace/country/FI-ASP-National-SoaringWeb.txt.json
+++ b/data/remote/airspace/country/FI-ASP-National-SoaringWeb.txt.json
@@ -1,5 +1,5 @@
 {
   "description": "Finland Airspace from SoaringWeb.org",
-  "update": "2024-06-25",
-  "uri": "https://soaring.silentflight.ca/Airspace/FI/FIN2024.txt"
+  "update": "2026-05-13",
+  "uri": "https://soaring.silentflight.ca/Airspace/FI/FIN2026.txt"
 }

--- a/data/remote/airspace/country/ZA-ASP-National-SoaringWeb.txt.json
+++ b/data/remote/airspace/country/ZA-ASP-National-SoaringWeb.txt.json
@@ -1,5 +1,5 @@
 {
   "description": "South Africa Airspace from SoaringWeb.org",
   "update": "2025-01-14",
-  "uri": "https://soaring.silentflight.ca/Airspace/ZA/SSSA-15JAN2025v2-Final.txt"
+  "uri": "https://soaring.silentflight.ca/Airspace/ZA/SSSA-15JAN2025v2a-Final.txt"
 }


### PR DESCRIPTION
Update for 2026


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Finland airspace data reference to the 2026 version, replacing the previous 2024 version reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->