### PR TITLE
checklist: refine example Folken checklist with vhf: links

### DIFF
--- a/data/content/checklist/global/xcsoar-checklist-example-folken.xcc
+++ b/data/content/checklist/global/xcsoar-checklist-example-folken.xcc
@@ -90,7 +90,7 @@ Example personal checklist contributed by Folken. Adapt frequencies, aerodrome-s
 - [ ] OpenVario on
 - [ ] FLARM on
 - [ ] XPDR on ALT, code 7000
-- [ ] VHF frequency set to local aerodrome
+- [ ] VHF frequency set to [LSPD](vhf:118.180#active)
 - [ ] Mission in mind
 - [ ] Emergency procedure reviewed
 - [ ] Radio check with tow (note callsign)
@@ -121,13 +121,13 @@ Example personal checklist contributed by Folken. Adapt frequencies, aerodrome-s
 
 - Release: "RL, 1988, ha klinkt"
 - Tango
-- 134.680 - Check for TMA activation
-- 130.900 - Bale Info clearance
+- [TMA activation](vhf:134.680#standby)
+- [Bale Info clearance](vhf:130.900#standby)
 
 ## Air-to-air
-- 124.030 Segelflug West (Jura Mittelland)
-- 123.580 Segelflug Nord (ostlich von Olten)
-- 123.680 Segelflug Alpen (sudlich der Mittelland/Alpen Trennlinie)
+- [Segelflug West](vhf:124.030#standby) (Jura Mittelland)
+- [Segelflug Nord](vhf:123.580#standby) (ostlich von Olten)
+- [Segelflug Alpen](vhf:123.680#standby) (sudlich der Mittelland/Alpen Trennlinie)
 
 [Airspace Switzerland]
 # Limits and schedule
@@ -145,7 +145,7 @@ Example personal checklist contributed by Folken. Adapt frequencies, aerodrome-s
 - Without listening watch: code 7000
 - Visible to ATC, no traffic information
 - With listening watch: code 2677
-- Frequency 119.925
+- Frequency [TMZ NE listening watch](vhf:119.925#standby)
 - Traffic information by ATC
 
 [Betriebsreglement LSPD]


### PR DESCRIPTION
## Summary
- Add and refine the global example Folken checklist (`xcsoar-checklist-example-folken.xcc`) with personal preflight, radio, airspace, and emergency reference pages.
- Convert key radio frequencies to XCSoar `vhf:…#active` / `vhf:…#standby` links (LSPD tower, TMA/Bale Info, Swiss air-to-air channels, TMZ listening watch) so they can be tuned directly from the checklist.

## Test plan
- [ ] Load `xcsoar-checklist-example-folken.xcc` in XCSoar (Site Files > Checklist)
- [ ] Tap each `vhf:` link and confirm standby/active frequency is set
- [ ] Verify `tel:` and `xcsoar://` links still work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "I'M SAFE" personal readiness checks to pre-flight procedures.
  * Integrated linked resources for weather, NOTAMs, and flight planning within the checklist.
  * Added flight task programming checks.

* **Improvements**
  * Enhanced radio frequency setup with streamlined link-based approach and air-to-air frequency options.
  * Updated post-flight workflow to focus on flight upload and plan closure.
  * Consolidated and reorganized checklist sections for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->