### PR TITLE
Update DE-ASP-National.txt

### DIFF
--- a/data/remote/airspace/country/DE-ASP-National-DAEC.txt.json
+++ b/data/remote/airspace/country/DE-ASP-National-DAEC.txt.json
@@ -1,5 +1,5 @@
 {
   "description": "Airspace Germany from DAEC",
-  "update": "2026-03-19",
-  "uri": "https://www.daec.de/media/files/Dateien/Fachbereiche/Luftraum_und_Flugsicherheit/2026_03_Airspace_Germany_OA1.txt"
+  "update": "2026-06-15",
+  "uri": "https://www.daec.de/media/files/Dateien/Fachbereiche/Luftraum_und_Flugsicherheit/2026_06_Airspace_Germany_OA1.txt"
 }


### PR DESCRIPTION
The two ED-Rs, Eickhofer Heide and Siedener Moor, which came into effect on 15 June 2026, have been newly included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated airspace reference data for Germany to reflect the latest June 2026 source materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->