### PR TITLE
fix: switch OpenAIP exports to public S3 storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 myoutdir
+__pycache__/
+data/remote/waypoint/country/

--- a/script/build/openaip_exports.py
+++ b/script/build/openaip_exports.py
@@ -1,0 +1,97 @@
+#!/bin/env python3
+"""Access OpenAIP daily system exports (public S3-compatible bucket).
+
+Docs: https://www.openaip.net/docs
+Bucket: https://storage.openaip.net/openaip-system-exports/
+Rate limits: 20 req/s, bursts up to 50 (see openAIP/openaip#469).
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from dataclasses import dataclass
+from typing import Iterator
+
+import requests
+
+OPENAIP_EXPORTS_BASE_URL = "https://storage.openaip.net/openaip-system-exports/"
+
+# Stay under the documented 20 req/s sustained limit.
+_DEFAULT_RATE = 15.0
+
+
+class _RateLimiter:
+    def __init__(self, rate: float = _DEFAULT_RATE) -> None:
+        self._min_interval = 1.0 / rate
+        self._lock = threading.Lock()
+        self._next = 0.0
+
+    def wait(self) -> None:
+        with self._lock:
+            now = time.monotonic()
+            if now < self._next:
+                time.sleep(self._next - now)
+                now = time.monotonic()
+            self._next = now + self._min_interval
+
+
+_limiter = _RateLimiter()
+_session = requests.Session()
+
+
+@dataclass(frozen=True)
+class ExportObject:
+    key: str
+    size: int
+    last_modified: str
+
+    @property
+    def url(self) -> str:
+        return OPENAIP_EXPORTS_BASE_URL + self.key
+
+
+def get(url: str, *, timeout: float = 60) -> requests.Response:
+    """Rate-limited GET against the exports endpoint (or any URL)."""
+    _limiter.wait()
+    response = _session.get(url, timeout=timeout)
+    response.raise_for_status()
+    return response
+
+
+def iter_exports() -> Iterator[ExportObject]:
+    """Yield all objects via anonymous S3 ListObjectsV2 pagination."""
+    params: dict[str, str] = {"list-type": "2"}
+    while True:
+        _limiter.wait()
+        response = _session.get(OPENAIP_EXPORTS_BASE_URL, params=params, timeout=60)
+        response.raise_for_status()
+        xml = response.text
+
+        for content in re.findall(r"<Contents>(.*?)</Contents>", xml, re.DOTALL):
+            key = re.search(r"<Key>(.*?)</Key>", content)
+            size = re.search(r"<Size>(.*?)</Size>", content)
+            modified = re.search(r"<LastModified>(.*?)</LastModified>", content)
+            if not (key and size and modified):
+                continue
+            yield ExportObject(
+                key=key.group(1),
+                size=int(size.group(1)),
+                last_modified=modified.group(1),
+            )
+
+        truncated = re.search(r"<IsTruncated>(.*?)</IsTruncated>", xml)
+        token = re.search(
+            r"<NextContinuationToken>(.*?)</NextContinuationToken>", xml
+        )
+        if (
+            not truncated
+            or truncated.group(1).lower() != "true"
+            or not token
+        ):
+            break
+        params = {
+            "list-type": "2",
+            "continuation-token": token.group(1),
+        }

--- a/script/build/repository.py
+++ b/script/build/repository.py
@@ -10,14 +10,14 @@ import json
 from pathlib import Path
 import subprocess
 import sys
-import requests
-import re
 from typing import Optional
 
 from iso3166 import countries
 from aerofiles.seeyou.reader import Reader as CupReader
 from aerofiles.openair.reader import Reader as OpenAirReader
 from aerofiles.errors import ParserError
+
+from openaip_exports import get as openaip_get, iter_exports
 
 
 def git_commit_datetime(filename: Path) -> datetime.datetime:
@@ -293,45 +293,16 @@ update={git_commit_datetime(datafile).date().isoformat()}
 
 
 def generate_asp_openaip():
-    """Generate OpenAIP repository entries from cloud storage (airspace files)."""
-    base_url = "https://storage.googleapis.com/29f98e10-a489-4c82-ae5e-489dbcd4912f/"
-    url = base_url
-    openaip_index = ""
+    """Generate OpenAIP repository entries from daily system exports."""
     rv = ""
 
-    # Fetch all pages of the OpenAIP index
-    while True:
-        response = requests.get(url, timeout=30)
-        xml_data = response.text
-        openaip_index += xml_data
-
-        match = re.search(r"<NextMarker>(.*?)</NextMarker>", xml_data)
-        if not match:
-            break
-        url = f"{base_url}?marker={match.group(1)}"
-
-    contents = re.findall(r"<Contents>(.*?)</Contents>", openaip_index)
-    for content in contents:
-        key_match = re.search(r"<Key>(.*?)</Key>", content)
-        if not key_match or "asp_v2.txt" not in key_match.group(1):
+    for obj in iter_exports():
+        if not obj.key.endswith("asp_v2.txt") or obj.size < 384:
             continue
 
-        size_match = re.search(r"<Size>(.*)</Size>", content)
-        if not size_match:
-            continue
+        print(f"OK: {obj.key} {obj.size}")
 
-        size = int(size_match.group(1))
-        if size < 384:
-            continue
-
-        key = key_match.group(1)
-        print(f"OK: {key} {size}")
-
-        updatedate_match = re.search(r"<LastModified>(.*?)</LastModified>", content)
-        if not updatedate_match:
-            continue
-
-        countrycode = key[:2].upper()
+        countrycode = obj.key[:2].upper()
         try:
             countryname = countries.get(countrycode).name
         except KeyError:
@@ -340,10 +311,8 @@ def generate_asp_openaip():
         # Download and parse airspace file to calculate bbox
         bbox = None
         try:
-            file_url = base_url + key
-            file_response = requests.get(file_url, timeout=30)
-            if file_response.status_code == 200:
-                bbox = calculate_bbox_airspace_from_content(file_response.text)
+            file_response = openaip_get(obj.url, timeout=30)
+            bbox = calculate_bbox_airspace_from_content(file_response.text)
         except Exception as e:
             print(f"Warning: Could not download/parse OpenAIP airspace for {countrycode}: {e}")
 
@@ -351,11 +320,11 @@ def generate_asp_openaip():
 
         rv += f"""
 name={countrycode}-ASP-National-OpenAIP.txt
-uri={base_url}{key}
+uri={obj.url}
 type=airspace
 description={countryname} Airspace from OpenAIP
 area={countrycode}
-update={updatedate_match.group(1)}
+update={obj.last_modified}
 {bbox_line}"""
     return rv
 

--- a/script/build/repository.py
+++ b/script/build/repository.py
@@ -329,6 +329,71 @@ update={obj.last_modified}
     return rv
 
 
+# CUPX type suffix -> repository name middle segment / description fragment.
+# Files stay on OpenAIP storage; we only index direct HTTPS URIs (no mirroring).
+_OPENAIP_CUPX_TYPES = {
+    "apt": ("Airports", "airports"),
+    "nav": ("Navaids", "navaids"),
+    "hgl": ("HangGliding", "hang gliding sites"),
+    "rca": ("RCAirfields", "RC airfields"),
+}
+
+
+def generate_cupx_openaip(out_content_dir: Optional[Path] = None) -> str:
+    """Generate OpenAIP CUPX repository entries with direct remote URIs.
+
+    Unlike national CUP files (concatenated and mirrored on download.xcsoar.org),
+    CUPX exports are listed as remote links to OpenAIP so XCSoar clients fetch
+    them from storage.openaip.net when selected.
+    """
+    rv = ""
+
+    for obj in iter_exports():
+        if not obj.key.endswith(".cupx"):
+            continue
+
+        stem = obj.key.removesuffix(".cupx")
+        if "_" not in stem:
+            continue
+        country_lc, typ = stem.split("_", 1)
+        type_info = _OPENAIP_CUPX_TYPES.get(typ)
+        if not type_info:
+            continue
+
+        name_mid, desc_kind = type_info
+        countrycode = country_lc.upper()
+        try:
+            countryname = countries.get(countrycode).name
+        except KeyError:
+            continue
+
+        print(f"OK: {obj.key} {obj.size}")
+
+        # Reuse national OpenAIP CUP bbox when available (no large CUPX download).
+        bbox_line = ""
+        if out_content_dir is not None:
+            national_cup = (
+                out_content_dir
+                / "waypoint"
+                / "country"
+                / f"{countrycode}-WPT-National-OpenAIP.cup"
+            )
+            if national_cup.exists():
+                bbox = calculate_bbox_cup(national_cup)
+                if bbox:
+                    bbox_line = f"bbox={bbox}\n"
+
+        rv += f"""
+name={countrycode}-WPT-{name_mid}-OpenAIP.cupx
+uri={obj.url}
+type=waypoint
+description={countryname} {desc_kind} from OpenAIP (CUPX)
+area={countrycode}
+update={obj.last_modified}
+{bbox_line}"""
+    return rv
+
+
 def json_uri(json_filename: Path) -> str:
     """Return the value of json_filename's "uri" key."""
     with json_filename.open() as f:
@@ -445,6 +510,7 @@ if __name__ == "__main__":
     repo += generate_source(data_dir=source_dir, url=base_url + "source/")
     repo += generate_remote(data_dir=remote_dir, out_content_dir=out_content_dir)
     repo += generate_asp_openaip()
+    repo += generate_cupx_openaip(out_content_dir=out_content_dir)
 
     out_path = out_dir / "repository"
 

--- a/script/build/xcsoar-openaip-generate-all-cup.py
+++ b/script/build/xcsoar-openaip-generate-all-cup.py
@@ -1,11 +1,13 @@
 #!/bin/env python3
 
-import requests
-import re
 import argparse
-import os
 import json
+import os
+
 from iso3166 import countries
+
+from openaip_exports import get as openaip_get, iter_exports
+
 
 # Function to parse command line arguments
 def parse_arguments():
@@ -13,49 +15,32 @@ def parse_arguments():
     parser.add_argument("output", help="Directory to save the files to")
     return parser.parse_args()
 
+
 # Function to ensure directories exist
 def ensure_directories(output_dir, metajson_dir):
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(metajson_dir, exist_ok=True)
 
-# Function to fetch data from the server with pagination
-def fetch_data(base_url):
-    url = base_url
-    openaip_index = ""
-    while True:
-        response = requests.get(url)
-        xml_data = response.text
-        openaip_index += xml_data
 
-        # Search for the NextMarker tag in the XML data
-        match = re.search(r"<NextMarker>(.*?)</NextMarker>", xml_data)
-        if not match:
-            break
-        next_marker = match.group(1)
-        url = f"{base_url}?marker={next_marker}"
-
-    return openaip_index
-
-# Function to process a single content block
-def process_content_block(content, base_url, output_dir, metajson_dir):
-    key = re.search(r"<Key>(.*?)</Key>", content)
-    if not key or not re.search(r"\.cup$", key.group(1)):
+# Function to process a single export object
+def process_export(obj, output_dir, metajson_dir):
+    if not obj.key.endswith(".cup"):
         return
 
-    country_code = key.group(1)[:2]
-    file_url = base_url + key.group(1)
+    country_code = obj.key[:2]
     cup_file_path = os.path.join(
         output_dir, f"{country_code.upper()}-WPT-National-OpenAIP.cup"
     )
 
     # Download file content
-    file_content = requests.get(file_url).text
+    file_content = openaip_get(obj.url).text
 
     # Write or append to the `.cup` file, filtering header lines
     write_cup_file(cup_file_path, file_content)
 
     # Create metadata JSON if applicable
     create_metadata(country_code, metajson_dir)
+
 
 # Function to write or append to a `.cup` file, filtering redundant headers
 
@@ -85,6 +70,7 @@ def write_cup_file(file_path, content):
         file.write(header + "\n")
         file.writelines(all_lines + [line + "\n" for line in new_lines])
 
+
 # Function to create metadata JSON for a country
 def create_metadata(country_code, metajson_dir):
     metadata = {
@@ -97,6 +83,7 @@ def create_metadata(country_code, metajson_dir):
     with open(metadata_file_path, "w", encoding="utf-8") as file:
         json.dump(metadata, file, ensure_ascii=False, indent=2)
 
+
 # Main function to orchestrate the workflow
 def main():
     args = parse_arguments()
@@ -106,14 +93,9 @@ def main():
     # Ensure directories exist
     ensure_directories(output_dir, metajson_dir)
 
-    # Fetch data
-    base_url = "https://storage.googleapis.com/29f98e10-a489-4c82-ae5e-489dbcd4912f/"
-    openaip_index = fetch_data(base_url)
+    for obj in iter_exports():
+        process_export(obj, output_dir, metajson_dir)
 
-    # Process each content block
-    contents = re.findall(r"<Contents>(.*?)</Contents>", openaip_index)
-    for content in contents:
-        process_content_block(content, base_url, output_dir, metajson_dir)
 
 if __name__ == "__main__":
     main()

--- a/script/build/xcsoar-openaip-repogen-asp.py
+++ b/script/build/xcsoar-openaip-repogen-asp.py
@@ -1,39 +1,19 @@
 #!/bin/env python3
 
-import requests
-import re
 from iso3166 import countries
 
-base_url = "https://storage.googleapis.com/29f98e10-a489-4c82-ae5e-489dbcd4912f/"
-url = base_url
-openaip_index = ""
+from openaip_exports import iter_exports
 
-while True:
-    response = requests.get(url)
-    xml_data = response.text
-    openaip_index += response.text
+for obj in iter_exports():
+    if not obj.key.endswith("asp_v2.txt"):
+        continue
 
-    # Search for the NextMarker tag in the XML data
-    next_marker = None
-    match = re.search(r"<NextMarker>(.*?)</NextMarker>", xml_data)
-    if match:
-        next_marker = match.group(1)
-    if next_marker is None:
-        break
-
-    url = f"{base_url}?marker={next_marker}"
-
-contents = re.findall(r"<Contents>(.*?)</Contents>", openaip_index)
-for content in contents:
-    key = re.search(r"<Key>(.*?)</Key>", content)
-    if key.group(1).__contains__("asp_v2.txt"):
-        updatedate = re.search(r"<LastModified>(.*?)</LastModified>", content)
-        countrycode = str.upper(str(key.group(1)[0:2]))
-        countryname = countries.get(countrycode).name
-        print("name=" + countrycode + "-ASP-national" + "-OpenAIP.txt")
-        print("uri=" + base_url + key.group(1))
-        print("type=airspace")
-        print("description=" + "OpenAIP Airspace for " + countryname)
-        print("area=" + key.group(1)[0:2])
-        print("update=" + updatedate.group(1))
-        print("")
+    countrycode = obj.key[:2].upper()
+    countryname = countries.get(countrycode).name
+    print("name=" + countrycode + "-ASP-national" + "-OpenAIP.txt")
+    print("uri=" + obj.url)
+    print("type=airspace")
+    print("description=" + "OpenAIP Airspace for " + countryname)
+    print("area=" + obj.key[:2])
+    print("update=" + obj.last_modified)
+    print("")


### PR DESCRIPTION
## Summary
- Point OpenAIP airspace and CUP builds at `https://storage.openaip.net/openaip-system-exports/` (ListObjectsV2 + rate limiting) after the old GCS bucket became Requester Pays.
- Index OpenAIP CUPX files (`apt` / `nav` / `hgl` / `rca`) as remote repository URIs so clients download from OpenAIP without XCSoar mirroring.
- Ignore generated OpenAIP country waypoint metadata and `__pycache__`.

Related: openAIP/openaip#469

## Test plan
- [ ] Run `script/build/xcsoar-openaip-generate-all-cup.py` and confirm national `*-WPT-National-OpenAIP.cup` files are produced
- [ ] Run `script/build/repository.py` and confirm OpenAIR entries use `storage.openaip.net` (no old GCS URLs)
- [ ] Confirm CUPX entries appear (e.g. `DE-WPT-Airports-OpenAIP.cupx`) with direct OpenAIP URIs
- [ ] Spot-check that DE waypoints index; DE airspace may still be missing while OpenAIP finishes filling the bucket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing OpenAIP airport, navigation aid, hang gliding, and airspace data.
  * Generated remote waypoint entries with country, timestamp, source, and optional geographic coverage metadata.
  * Added support for producing country-specific waypoint and airspace files from OpenAIP exports.

* **Improvements**
  * Updated OpenAIP data retrieval to improve reliability and handle large export collections more efficiently.
  * Incomplete or unsupported export entries are now skipped automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->