### PR TITLE
Populate map area metadata

### DIFF
--- a/script/build/download-file.py
+++ b/script/build/download-file.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/script/build/map_area.py
+++ b/script/build/map_area.py
@@ -1,0 +1,49 @@
+"""Country-area inference shared by map manifest generators.
+
+Map file names conventionally start with an ISO country identifier, followed
+by an underscore (for example ``AUS_ADELAIDE``).  A small number of historic
+names do not follow that convention; keep their meanings explicit here so
+every generated map manifest uses the same safe result.
+"""
+
+from iso3166 import countries
+
+
+# Map stems whose country cannot be inferred safely from their prefix.
+# An empty value deliberately leaves a multi-country or ambiguous map
+# ungrouped in the repository.
+AREA_OVERRIDES = {
+    "ALPS": "",
+    "BEN_WGER": "",
+    "BUL": "bg",
+    "UK": "gb",
+    "GER": "de",
+    "IRE": "ie",
+    "POR": "pt",
+    "TURKEY": "tr",
+}
+
+
+def guess_area(name: str) -> str:
+    """Return a lowercase ISO-3166 alpha-2 area for a map stem, if known.
+
+    The complete stem is considered first, preserving country names that
+    contain hyphens. The remaining candidates remove underscore- or
+    hyphen-separated suffixes from right to left. ``iso3166`` accepts alpha-2,
+    alpha-3, and supported country names. Unknown identifiers produce no area.
+    """
+    stem = name.rsplit(".", 1)[0]
+    override = AREA_OVERRIDES.get(stem.upper())
+    if override is not None:
+        return override
+
+    candidate = stem
+    while candidate:
+        try:
+            return countries.get(candidate).alpha2.lower()
+        except KeyError:
+            separator = max(candidate.rfind("_"), candidate.rfind("-"))
+            if separator < 0:
+                break
+            candidate = candidate[:separator]
+    return ""

--- a/script/build/maps_config_js.py
+++ b/script/build/maps_config_js.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import subprocess
 import sys
 
-from iso3166 import countries
+from map_area import guess_area
 
 
 def git_commit_datetime(filename: Path) -> datetime.datetime:
@@ -16,17 +16,6 @@ def git_commit_datetime(filename: Path) -> datetime.datetime:
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     out, _ = p.communicate()
     return datetime.datetime.utcfromtimestamp(int(out))
-
-
-def guess_area(name: str) -> str:
-    """From name (e.g. USA_PG_REG1-4), try to guess and return the ISO3166.1-alpha2 code, else empty string."""
-    area = ""
-    prefix = name.split("_")[0]
-    try:
-        area = countries.get(prefix).alpha2.lower()
-    except KeyError:
-        print(f"Could not guess the country code (ISO 3166 alpha2 ) for: {name}")
-    return area
 
 
 def gen_map_json(in_dir: Path, out_path: Path) -> None:

--- a/script/build/maps_config_js.py
+++ b/script/build/maps_config_js.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 """Auto-generate https://github.com/XCSoar/xcsoar-data-repository/blob/master/data/maps.json."""
 
 import datetime

--- a/script/build/openaip_exports.py
+++ b/script/build/openaip_exports.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 """Access OpenAIP daily system exports (public S3-compatible bucket).
 
 Docs: https://www.openaip.net/docs

--- a/script/build/repository.py
+++ b/script/build/repository.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 """
 Generate XCSoar's repository file (https://download.xcsoar.org/repository).
 

--- a/script/build/repository.py
+++ b/script/build/repository.py
@@ -18,6 +18,7 @@ from aerofiles.openair.reader import Reader as OpenAirReader
 from aerofiles.errors import ParserError
 
 from openaip_exports import get as openaip_get, iter_exports
+from map_area import guess_area
 
 
 def git_commit_datetime(filename: Path) -> datetime.datetime:
@@ -34,17 +35,6 @@ def git_commit_datetime(filename: Path) -> datetime.datetime:
     except (ValueError, OSError):
         # Return naive UTC datetime
         return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
-
-
-def guess_area(name: str) -> str:
-    """From name (e.g. USA-PG-REG1-4), try to guess and return the ISO3166.1-alpha2 code, else empty string."""
-    area = ""
-    prefix = name.split(".")[0].split("-")[0]
-    try:
-        area = countries.get(prefix).alpha2.lower()
-    except KeyError:
-        print(f"Could not guess the country code (ISO 3166 alpha2) for: {name}")
-    return area
 
 
 def calculate_bbox_cup(cup_file: Path) -> Optional[str]:

--- a/script/build/sortrepo.py
+++ b/script/build/sortrepo.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/script/build/waypoints_js.py
+++ b/script/build/waypoints_js.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 """
 Auto-generate these files from directory listing xcsoar-data-content/waypoints:
 

--- a/script/build/xcsoar-openaip-generate-all-cup.py
+++ b/script/build/xcsoar-openaip-generate-all-cup.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import argparse
 import json

--- a/script/build/xcsoar-openaip-repogen-asp.py
+++ b/script/build/xcsoar-openaip-repogen-asp.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 from iso3166 import countries
 

--- a/script/check/check_airspaces.py
+++ b/script/check/check_airspaces.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 from aerofiles.openair.reader import Reader as OpenAirReader

--- a/script/check/check_urls.py
+++ b/script/check/check_urls.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 """Check if all the repository URLs are working."""
 
 import sys

--- a/script/check/check_waypoints.py
+++ b/script/check/check_waypoints.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 from aerofiles.seeyou.reader import Reader as CupFileReader

--- a/script/check/check_waypoints_country.py
+++ b/script/check/check_waypoints_country.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 """Ensure that waypoints/countries are named correctly, and pass an Aerofiles check."""
 
 from pathlib import Path

--- a/tests/test_map_area.py
+++ b/tests/test_map_area.py
@@ -1,0 +1,36 @@
+"""Tests for country-area inference used by generated map manifests."""
+
+from pathlib import Path
+import sys
+import unittest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "script" / "build"))
+
+from map_area import guess_area  # noqa: E402
+
+
+class GuessAreaTest(unittest.TestCase):
+    def test_country_prefixes(self):
+        self.assertEqual(guess_area("AUS_ADELAIDE"), "au")
+        self.assertEqual(guess_area("US_COLORADO"), "us")
+        self.assertEqual(guess_area("FRA_ALPS"), "fr")
+        self.assertEqual(guess_area("Timor-Leste"), "tl")
+        self.assertEqual(guess_area("Timor-Leste-Dili"), "tl")
+
+    def test_historic_name_overrides(self):
+        self.assertEqual(guess_area("UK"), "gb")
+        self.assertEqual(guess_area("GER"), "de")
+        self.assertEqual(guess_area("IRE"), "ie")
+        self.assertEqual(guess_area("BUL"), "bg")
+        self.assertEqual(guess_area("POR"), "pt")
+        self.assertEqual(guess_area("Turkey"), "tr")
+
+    def test_ambiguous_maps_remain_ungrouped(self):
+        self.assertEqual(guess_area("ALPS"), "")
+        self.assertEqual(guess_area("BEN_WGER"), "")
+        self.assertEqual(guess_area("UNKNOWN_REGION"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Before

`repository.py` split map names only on `-`. Most regional maps use `_`, such as `AUS_ADELAIDE` and `US_COLORADO`, so their country prefix was not resolved. Only 18 of 160 generated map entries had an `area`; 142 were blank. 

This prevents XCSoar from properly grouping map downloads by country.

## After

Both map manifest generators use the same country-area helper. It reads the first `_`- or `-`-separated name component and converts supported ISO alpha-2, alpha-3, or country-name identifiers to lowercase ISO-3166 alpha-2 values.

| Map name | Previous area | New area |
| --- | --- | --- |
| `AUS_ADELAIDE` | empty | `au` |
| `US_COLORADO` | empty | `us` |
| `FRA_ALPS` | empty | `fr` |
| `UK` | empty | `gb` |
| `GER` | empty | `de` |

The generated manifest now has areas on 156 of 160 entries. `ALPS` and `BEN_WGER` (Benelux - Western Germany) deliberately remain empty because they are multi-country or ambiguous.

Both standard and `_HighRes.xcm` variants match.

Legacy map names that ISO lookup cannot resolve directly (`BUL`, `POR`, `UK`, `GER`, `IRE`, and `Turkey`) have explicit shared overrides. 

Tests cover normal prefix inference, overrides, and intentionally empty values.

The accompanying shebang commit changes Python helpers from `#!/bin/env` to `#!/usr/bin/env`, allowing the build scripts to execute directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Map processing now identifies country areas more consistently, including historical names and ambiguous or unknown map names.
  - Build and validation tools now use a more portable Python launch configuration, improving execution across supported environments.

- **Bug Fixes**
  - Corrected interpreter lookup paths for map generation, data export, sorting, and validation tools.

- **Tests**
  - Added coverage for country detection, historical naming, and handling of unrecognized map names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->