### PR TITLE
feat(maps): emit File Manager descriptions in the repository

### DIFF
--- a/data/source/map/country/Denmark.json
+++ b/data/source/map/country/Denmark.json
@@ -4,5 +4,6 @@
     53.53,
     15.84,
     58.03
-  ]
+  ],
+  "description": "Map of Denmark"
 }

--- a/data/source/map/country/Turkey.json
+++ b/data/source/map/country/Turkey.json
@@ -5,5 +5,6 @@
     44.81,
     42.09
   ],
+  "description": "Map of Turkey",
   "update": "2023-02-15"
 }

--- a/data/source/map/region/ALPS.json
+++ b/data/source/map/region/ALPS.json
@@ -5,5 +5,6 @@
     16.5,
     49
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of the Alps"
 }

--- a/data/source/map/region/ARG_ANDES.json
+++ b/data/source/map/region/ARG_ANDES.json
@@ -5,5 +5,6 @@
     -69,
     -36
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of the Andes, Argentina"
 }

--- a/data/source/map/region/ARG_CENTRO.json
+++ b/data/source/map/region/ARG_CENTRO.json
@@ -5,5 +5,6 @@
     -57,
     -33
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of central Argentina"
 }

--- a/data/source/map/region/ARG_NORTE.json
+++ b/data/source/map/region/ARG_NORTE.json
@@ -5,5 +5,6 @@
     -58,
     -30
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of northern Argentina"
 }

--- a/data/source/map/region/AUS_ADELAIDE.json
+++ b/data/source/map/region/AUS_ADELAIDE.json
@@ -5,5 +5,6 @@
     141,
     -33
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Adelaide, Australia"
 }

--- a/data/source/map/region/AUS_BENALLA.json
+++ b/data/source/map/region/AUS_BENALLA.json
@@ -5,5 +5,6 @@
     149,
     -31
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Benalla, Australia"
 }

--- a/data/source/map/region/AUS_NORTHNSW.json
+++ b/data/source/map/region/AUS_NORTHNSW.json
@@ -5,5 +5,6 @@
     151.8,
     -28.3
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of northern New South Wales, Australia"
 }

--- a/data/source/map/region/AUS_NSW_VIC.json
+++ b/data/source/map/region/AUS_NSW_VIC.json
@@ -5,5 +5,6 @@
     154,
     -29
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of New South Wales and Victoria, Australia"
 }

--- a/data/source/map/region/AUS_QLD.json
+++ b/data/source/map/region/AUS_QLD.json
@@ -5,5 +5,6 @@
     153,
     -25
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of south-east Queensland, Australia"
 }

--- a/data/source/map/region/AUS_WA.json
+++ b/data/source/map/region/AUS_WA.json
@@ -5,5 +5,6 @@
     120,
     -24.9
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of south-west Western Australia"
 }

--- a/data/source/map/region/BEN_WGER.json
+++ b/data/source/map/region/BEN_WGER.json
@@ -5,5 +5,6 @@
     13,
     54
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Benelux and western Germany"
 }

--- a/data/source/map/region/BRA_CENTRO_OESTE.json
+++ b/data/source/map/region/BRA_CENTRO_OESTE.json
@@ -5,5 +5,6 @@
     -45.8,
     -14.6
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Centre-West Brazil"
 }

--- a/data/source/map/region/BRA_SOUTH.json
+++ b/data/source/map/region/BRA_SOUTH.json
@@ -5,5 +5,6 @@
     -47,
     -22
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern Brazil"
 }

--- a/data/source/map/region/BRA_SUDESTE.json
+++ b/data/source/map/region/BRA_SUDESTE.json
@@ -5,5 +5,6 @@
     -39.3,
     -16.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Southeast Brazil"
 }

--- a/data/source/map/region/BUL.json
+++ b/data/source/map/region/BUL.json
@@ -5,5 +5,6 @@
     29,
     44.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Bulgaria"
 }

--- a/data/source/map/region/CAN_ONTARIO.json
+++ b/data/source/map/region/CAN_ONTARIO.json
@@ -5,5 +5,6 @@
     -74,
     55
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Ontario, Canada"
 }

--- a/data/source/map/region/CAN_QUEBEC_S.json
+++ b/data/source/map/region/CAN_QUEBEC_S.json
@@ -5,5 +5,6 @@
     -70.2,
     47.2
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern Quebec, Canada"
 }

--- a/data/source/map/region/CAN_SE_BC_AB.json
+++ b/data/source/map/region/CAN_SE_BC_AB.json
@@ -5,5 +5,6 @@
     -109,
     55
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southeast British Columbia and Alberta, Canada"
 }

--- a/data/source/map/region/CAN_SE_ONTARIO.json
+++ b/data/source/map/region/CAN_SE_ONTARIO.json
@@ -5,5 +5,6 @@
     -73.5,
     46.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southeast Ontario, Canada"
 }

--- a/data/source/map/region/CAN_SW_ONTARIO.json
+++ b/data/source/map/region/CAN_SW_ONTARIO.json
@@ -5,5 +5,6 @@
     -78,
     46
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southwest Ontario, Canada"
 }

--- a/data/source/map/region/CAN_S_SK_MA.json
+++ b/data/source/map/region/CAN_S_SK_MA.json
@@ -5,5 +5,6 @@
     -94.8,
     53.9
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern Saskatchewan and Manitoba, Canada"
 }

--- a/data/source/map/region/CL_CHILE_CENTRO.json
+++ b/data/source/map/region/CL_CHILE_CENTRO.json
@@ -5,5 +5,6 @@
     -69.5,
     -29.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of central Chile"
 }

--- a/data/source/map/region/COLOMBIA.json
+++ b/data/source/map/region/COLOMBIA.json
@@ -5,5 +5,6 @@
     -70,
     8
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Colombia"
 }

--- a/data/source/map/region/CZ_SK.json
+++ b/data/source/map/region/CZ_SK.json
@@ -5,5 +5,6 @@
     22.35,
     51.4
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Czechia and Slovakia"
 }

--- a/data/source/map/region/ESP_BALEAR.json
+++ b/data/source/map/region/ESP_BALEAR.json
@@ -5,5 +5,6 @@
     4.4,
     40.1
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of the Balearic Islands, Spain"
 }

--- a/data/source/map/region/ESP_C.json
+++ b/data/source/map/region/ESP_C.json
@@ -5,5 +5,6 @@
     1.8,
     41
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of central Spain"
 }

--- a/data/source/map/region/ESP_N.json
+++ b/data/source/map/region/ESP_N.json
@@ -5,5 +5,6 @@
     3.4,
     43.8
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of northern Spain"
 }

--- a/data/source/map/region/ESP_S.json
+++ b/data/source/map/region/ESP_S.json
@@ -5,5 +5,6 @@
     0.3,
     39.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern Spain"
 }

--- a/data/source/map/region/FIN.json
+++ b/data/source/map/region/FIN.json
@@ -5,5 +5,6 @@
     31.9,
     70.3
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Finland"
 }

--- a/data/source/map/region/FRA_ALPS.json
+++ b/data/source/map/region/FRA_ALPS.json
@@ -5,5 +5,6 @@
     9,
     47.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of the French Alps"
 }

--- a/data/source/map/region/FRA_CORSE.json
+++ b/data/source/map/region/FRA_CORSE.json
@@ -5,5 +5,6 @@
     10,
     43
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Corsica, France"
 }

--- a/data/source/map/region/FRA_FULL.json
+++ b/data/source/map/region/FRA_FULL.json
@@ -5,5 +5,6 @@
     9,
     51.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of France"
 }

--- a/data/source/map/region/FRA_SW.json
+++ b/data/source/map/region/FRA_SW.json
@@ -5,5 +5,6 @@
     4,
     47
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of south-west France"
 }

--- a/data/source/map/region/GER.json
+++ b/data/source/map/region/GER.json
@@ -5,5 +5,6 @@
     15.5,
     55
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Germany"
 }

--- a/data/source/map/region/HUN.json
+++ b/data/source/map/region/HUN.json
@@ -5,5 +5,6 @@
     22.9,
     48.6
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Hungary"
 }

--- a/data/source/map/region/IRE.json
+++ b/data/source/map/region/IRE.json
@@ -5,5 +5,6 @@
     -5.3,
     55.4
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Ireland"
 }

--- a/data/source/map/region/ISR_ISRAEL.json
+++ b/data/source/map/region/ISR_ISRAEL.json
@@ -5,5 +5,6 @@
     36.2,
     33.8
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Israel"
 }

--- a/data/source/map/region/ITA_APENN.json
+++ b/data/source/map/region/ITA_APENN.json
@@ -5,5 +5,6 @@
     15,
     45.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of the Apennines, Italy"
 }

--- a/data/source/map/region/ITA_S.json
+++ b/data/source/map/region/ITA_S.json
@@ -5,5 +5,6 @@
     18.5,
     41.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern Italy"
 }

--- a/data/source/map/region/ITA_SARD.json
+++ b/data/source/map/region/ITA_SARD.json
@@ -5,5 +5,6 @@
     10,
     41.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Sardinia, Italy"
 }

--- a/data/source/map/region/JP_HOK.json
+++ b/data/source/map/region/JP_HOK.json
@@ -5,5 +5,6 @@
     147,
     46
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Hokkaido, Japan"
 }

--- a/data/source/map/region/MEX_CENTER.json
+++ b/data/source/map/region/MEX_CENTER.json
@@ -5,5 +5,6 @@
     -95,
     21.6
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of central Mexico"
 }

--- a/data/source/map/region/MW.json
+++ b/data/source/map/region/MW.json
@@ -5,5 +5,6 @@
     36.4,
     -8.7
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Malawi"
 }

--- a/data/source/map/region/NAM.json
+++ b/data/source/map/region/NAM.json
@@ -5,5 +5,6 @@
     25.5,
     -16.7
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Namibia"
 }

--- a/data/source/map/region/NOR_N.json
+++ b/data/source/map/region/NOR_N.json
@@ -5,5 +5,6 @@
     31,
     72.1
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of northern Norway"
 }

--- a/data/source/map/region/NOR_S.json
+++ b/data/source/map/region/NOR_S.json
@@ -5,5 +5,6 @@
     13,
     71.1
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern Norway"
 }

--- a/data/source/map/region/NZL_BOTHISLANDS.json
+++ b/data/source/map/region/NZL_BOTHISLANDS.json
@@ -5,5 +5,6 @@
     178.51,
     -34.46
   ],
-  "builddate": "2023-02-13"
+  "builddate": "2023-02-13",
+  "description": "Map of New Zealand"
 }

--- a/data/source/map/region/NZL_SOUTHISLAND.json
+++ b/data/source/map/region/NZL_SOUTHISLAND.json
@@ -5,5 +5,6 @@
     174.3,
     -39.4
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of the South Island, New Zealand"
 }

--- a/data/source/map/region/POL.json
+++ b/data/source/map/region/POL.json
@@ -5,5 +5,6 @@
     24.5,
     55
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Poland"
 }

--- a/data/source/map/region/POR.json
+++ b/data/source/map/region/POR.json
@@ -5,5 +5,6 @@
     -6,
     41.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Portugal"
 }

--- a/data/source/map/region/SWE_C.json
+++ b/data/source/map/region/SWE_C.json
@@ -5,5 +5,6 @@
     19.2,
     62.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of central Sweden"
 }

--- a/data/source/map/region/SWE_N.json
+++ b/data/source/map/region/SWE_N.json
@@ -5,5 +5,6 @@
     21.7,
     67
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of northern Sweden"
 }

--- a/data/source/map/region/SWE_S.json
+++ b/data/source/map/region/SWE_S.json
@@ -5,5 +5,6 @@
     18.1,
     59
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern Sweden"
 }

--- a/data/source/map/region/UA.json
+++ b/data/source/map/region/UA.json
@@ -5,5 +5,6 @@
     40.4,
     52.4
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Ukraine"
 }

--- a/data/source/map/region/UK.json
+++ b/data/source/map/region/UK.json
@@ -5,5 +5,6 @@
     2,
     59
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of the United Kingdom"
 }

--- a/data/source/map/region/US_AZ_PLUS.json
+++ b/data/source/map/region/US_AZ_PLUS.json
@@ -5,5 +5,6 @@
     -106,
     38
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Arizona and surroundings, United States"
 }

--- a/data/source/map/region/US_CALIFORN_S.json
+++ b/data/source/map/region/US_CALIFORN_S.json
@@ -5,5 +5,6 @@
     -114,
     37
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern California, United States"
 }

--- a/data/source/map/region/US_CA_TRUCKEE.json
+++ b/data/source/map/region/US_CA_TRUCKEE.json
@@ -5,5 +5,6 @@
     -113,
     43
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Truckee, California, United States"
 }

--- a/data/source/map/region/US_COLORADO.json
+++ b/data/source/map/region/US_COLORADO.json
@@ -5,5 +5,6 @@
     -102,
     41
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Colorado, United States"
 }

--- a/data/source/map/region/US_FL_CENTRAL.json
+++ b/data/source/map/region/US_FL_CENTRAL.json
@@ -5,5 +5,6 @@
     -80.5,
     29.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of central Florida, United States"
 }

--- a/data/source/map/region/US_HI_OAHU.json
+++ b/data/source/map/region/US_HI_OAHU.json
@@ -5,5 +5,6 @@
     -157.6,
     21.75
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Oahu, Hawaii, United States"
 }

--- a/data/source/map/region/US_HOBBS.json
+++ b/data/source/map/region/US_HOBBS.json
@@ -5,5 +5,6 @@
     -100.5,
     36
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Hobbs, New Mexico, United States"
 }

--- a/data/source/map/region/US_ID_LOST_RIVER.json
+++ b/data/source/map/region/US_ID_LOST_RIVER.json
@@ -5,5 +5,6 @@
     -110.5,
     47
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Lost River, Idaho, United States"
 }

--- a/data/source/map/region/US_ID_SOUTHWEST.json
+++ b/data/source/map/region/US_ID_SOUTHWEST.json
@@ -5,5 +5,6 @@
     -112.7,
     45.5
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southwest Idaho, United States"
 }

--- a/data/source/map/region/US_ILLINOIS_NO.json
+++ b/data/source/map/region/US_ILLINOIS_NO.json
@@ -5,5 +5,6 @@
     -87,
     44
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of northern Illinois, United States"
 }

--- a/data/source/map/region/US_ILLINOIS_SO.json
+++ b/data/source/map/region/US_ILLINOIS_SO.json
@@ -5,5 +5,6 @@
     -87,
     40
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of southern Illinois, United States"
 }

--- a/data/source/map/region/US_INDIANA.json
+++ b/data/source/map/region/US_INDIANA.json
@@ -5,5 +5,6 @@
     -84,
     42
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Indiana, United States"
 }

--- a/data/source/map/region/US_MICHIGAN.json
+++ b/data/source/map/region/US_MICHIGAN.json
@@ -5,5 +5,6 @@
     -82.5,
     45
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Michigan, United States"
 }

--- a/data/source/map/region/US_NEWENGLAND.json
+++ b/data/source/map/region/US_NEWENGLAND.json
@@ -5,5 +5,6 @@
     -68.9,
     45
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of New England, United States"
 }

--- a/data/source/map/region/US_NEWMEXICO.json
+++ b/data/source/map/region/US_NEWMEXICO.json
@@ -5,5 +5,6 @@
     -102.5,
     37
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of New Mexico, United States"
 }

--- a/data/source/map/region/US_NORTHEAST.json
+++ b/data/source/map/region/US_NORTHEAST.json
@@ -5,5 +5,6 @@
     -70,
     45
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of the northeastern United States"
 }

--- a/data/source/map/region/US_OK_HINTON.json
+++ b/data/source/map/region/US_OK_HINTON.json
@@ -5,5 +5,6 @@
     -95.5,
     39
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Hinton, Oklahoma, United States"
 }

--- a/data/source/map/region/US_OR_STATE.json
+++ b/data/source/map/region/US_OR_STATE.json
@@ -5,5 +5,6 @@
     -117,
     46
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Oregon, United States"
 }

--- a/data/source/map/region/US_SW_OHIO.json
+++ b/data/source/map/region/US_SW_OHIO.json
@@ -4,5 +4,6 @@
     38,
     -81,
     41
-  ]
+  ],
+  "description": "Map of southwest Ohio, United States"
 }

--- a/data/source/map/region/US_TEXAS.json
+++ b/data/source/map/region/US_TEXAS.json
@@ -5,5 +5,6 @@
     -93,
     36
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Texas, United States"
 }

--- a/data/source/map/region/US_UTAH_R9N.json
+++ b/data/source/map/region/US_UTAH_R9N.json
@@ -5,5 +5,6 @@
     -108.86,
     44
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of northern Utah, United States"
 }

--- a/data/source/map/region/US_WA_STATE.json
+++ b/data/source/map/region/US_WA_STATE.json
@@ -5,5 +5,6 @@
     -117,
     49
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of Washington, United States"
 }

--- a/data/source/map/region/ZA.json
+++ b/data/source/map/region/ZA.json
@@ -5,5 +5,6 @@
     35.8,
     -22
   ],
-  "builddate": "2022-07-19"
+  "builddate": "2022-07-19",
+  "description": "Map of South Africa"
 }

--- a/script/build/generate_maps.sh
+++ b/script/build/generate_maps.sh
@@ -16,7 +16,10 @@ mkdir -p "${MAPGEN_TMPDIR}/data"
 # Description-only JSON edits must not rebuild .xcm files.
 filter_maps_mod_bbox() {
   local ref="$1"
-  MAPS_MOD=$(python3 - "$ref" ${MAPS_MOD} <<'PY'
+  local -a maps_mod
+  # Word-split the space-separated path list into argv.
+  read -r -a maps_mod <<< "${MAPS_MOD}"
+  MAPS_MOD=$(python3 - "$ref" "${maps_mod[@]}" <<'PY'
 import json, subprocess, sys
 ref = sys.argv[1]
 keep = []

--- a/script/build/generate_maps.sh
+++ b/script/build/generate_maps.sh
@@ -13,6 +13,30 @@ OUT="${1}"
 MAPGEN_TMPDIR="$(mktemp -d -p "${PWD}" )"
 mkdir -p "${MAPGEN_TMPDIR}/data"
 
+# Description-only JSON edits must not rebuild .xcm files.
+filter_maps_mod_bbox() {
+  local ref="$1"
+  MAPS_MOD=$(python3 - "$ref" ${MAPS_MOD} <<'PY'
+import json, subprocess, sys
+ref = sys.argv[1]
+keep = []
+for path in sys.argv[2:]:
+    new = json.load(open(path, encoding="utf-8"))
+    proc = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        keep.append(path)
+        continue
+    old = json.loads(proc.stdout)
+    if old.get("bounding_box") != new.get("bounding_box"):
+        keep.append(path)
+print(" ".join(keep))
+PY
+)
+}
+
 if [ "${BUILD_MAPS}" == "true" ]; then
   MAPS_NEW=$(find ./data/source/map/ -type f -iname "*.json")
 
@@ -20,14 +44,17 @@ else
 
   REMOTE_NAME="$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)"
 
+  MAP_DIFF_REF=""
   if [[ -n "${PREVIOUS_COMMIT}" || -n "${PREVIOUS_COMMIT_PR}" ]]; then
       if [ -n "${PREVIOUS_COMMIT}" ]; then
+        MAP_DIFF_REF="${PREVIOUS_COMMIT}"
         MAPS_NEW=$(git diff --name-status "${PREVIOUS_COMMIT}" | grep 'data/source/map' | grep ^A | cut -f2)
         MAPS_MVE=$(git diff --name-status "${PREVIOUS_COMMIT}" | grep 'data/source/map' | grep ^R100 | cut -f2)
         MAPS_MOD=$(git diff --name-status "${PREVIOUS_COMMIT}" | grep 'data/source/map' | grep ^M | cut -f2)
       fi
 
       if [ -n "${PREVIOUS_COMMIT_PR}" ]; then
+        MAP_DIFF_REF="${PREVIOUS_COMMIT_PR}"
         MAPS_NEW=$(git diff --name-status "${PREVIOUS_COMMIT_PR}" | grep 'data/source/map' | grep ^A | cut -f2)
         MAPS_MVE=$(git diff --name-status "${PREVIOUS_COMMIT_PR}" | grep 'data/source/map' | grep ^R100 | cut -f2)
         MAPS_MOD=$(git diff --name-status "${PREVIOUS_COMMIT_PR}" | grep 'data/source/map' | grep ^M | cut -f2)
@@ -37,12 +64,17 @@ else
   git remote add "${REMOTE_NAME}" https://github.com/XCSoar/xcsoar-data-content.git
   git fetch "${REMOTE_NAME}"
 
+  MAP_DIFF_REF="$(git rev-parse "${REMOTE_NAME}/master")"
   MAPS_NEW=$(git diff --name-status "${REMOTE_NAME}"/master | grep 'data/source/map' | grep ^A | cut -f2)
   MAPS_MVE=$(git diff --name-status "${REMOTE_NAME}"/master | grep 'data/source/map' | grep ^R100 | cut -f2)
   MAPS_MOD=$(git diff --name-status "${REMOTE_NAME}"/master | grep 'data/source/map' | grep ^M | cut -f2)
   _MAPS_DEL=$(git diff --name-status "${REMOTE_NAME}"/master | grep 'data/source/map' | grep ^D | cut -f2)
 
   git remote remove "${REMOTE_NAME}"
+  fi
+
+  if [ -n "${MAP_DIFF_REF}" ] && [ -n "${MAPS_MOD}" ]; then
+    filter_maps_mod_bbox "${MAP_DIFF_REF}"
   fi
 
   # Check if any maps have been modified, else exit

--- a/script/build/repository.py
+++ b/script/build/repository.py
@@ -276,7 +276,8 @@ def generate_source(data_dir: Path, url: str) -> str:
                 bbox_line = f"bbox={bbox}\n" if bbox else ""
                 base_name = datafile.stem
                 base_uri = str(datafile.relative_to(data_dir)).replace(".json", "")
-                desc_line = f"description=Map of {base_name.replace('_', ' ')}\n"
+                description = json_description(datafile)
+                desc_line = f"description={description}\n" if description else ""
 
                 rv += f"""
 name={base_name}_HighRes.xcm

--- a/script/build/repository.py
+++ b/script/build/repository.py
@@ -276,6 +276,7 @@ def generate_source(data_dir: Path, url: str) -> str:
                 bbox_line = f"bbox={bbox}\n" if bbox else ""
                 base_name = datafile.stem
                 base_uri = str(datafile.relative_to(data_dir)).replace(".json", "")
+                desc_line = f"description=Map of {base_name.replace('_', ' ')}\n"
 
                 rv += f"""
 name={base_name}_HighRes.xcm
@@ -283,12 +284,12 @@ uri={url}{base_uri}_HighRes.xcm
 type={xcs_type.name}
 area={guess_area(base_name)}
 update={git_commit_datetime(datafile).date().isoformat()}
-{bbox_line}name={base_name}.xcm
+{desc_line}{bbox_line}name={base_name}.xcm
 uri={url}{base_uri}.xcm
 type={xcs_type.name}
 area={guess_area(base_name)}
 update={git_commit_datetime(datafile).date().isoformat()}
-{bbox_line}"""
+{desc_line}{bbox_line}"""
     return rv
 
 


### PR DESCRIPTION
## Summary
- Write a `description=` line for map entries so File Manager is not blank on the second row.
- Prefer the JSON `description` when present; otherwise use `Map of <stem>`.

## Test plan
- [ ] Generate the repository file and confirm map records include `description=`
- [ ] Confirm a map JSON with `description` overrides the fallback
- [ ] Confirm high-res and normal maps share the same description